### PR TITLE
feat: 매칭 세션 관리, 이벤트 기반 실시간 채팅 기능 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 	// JWT 간소화
 	implementation ("io.jsonwebtoken:jjwt:0.12.5")
+	// Java 8 Date/Time (LocalDateTime) 직렬화
+	implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/example/mentoring/auth/dto/LoginResponse.java
+++ b/src/main/java/com/example/mentoring/auth/dto/LoginResponse.java
@@ -1,5 +1,6 @@
 package com.example.mentoring.auth.dto;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,7 +21,7 @@ public class LoginResponse {
   @Builder.Default
   private String tokenType = "Bearer";
 
-  private Integer userId;
+  private UUID userId;
   private String email;
   private String nickname;
   private String role;

--- a/src/main/java/com/example/mentoring/auth/service/CustomUserDetails.java
+++ b/src/main/java/com/example/mentoring/auth/service/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.auth.service;
 
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
@@ -53,7 +54,7 @@ public class CustomUserDetails implements UserDetails {
     return user.getIsActive();
   }
 
-  public Integer getUserId() {
+  public UUID getUserId() {
     return user.getId();
   }
 

--- a/src/main/java/com/example/mentoring/chat/config/ChatHandshakeInterceptor.java
+++ b/src/main/java/com/example/mentoring/chat/config/ChatHandshakeInterceptor.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.chat.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
@@ -23,12 +24,14 @@ public class ChatHandshakeInterceptor implements HandshakeInterceptor {
       // URL에서 PathVariable (sessionId) 추출
       String path = httpRequest.getRequestURI();
       String[] pathSegments = path.split("/");
-      String sessionId = pathSegments[pathSegments.length - 1];
+      String sessionIdString = pathSegments[pathSegments.length - 1];
 
       try {
-        attributes.put("sessionId", Integer.parseInt(sessionId));
-      } catch (NumberFormatException e) {
-        return false; // 세션 ID가 숫자가 아니면 연결 거부
+        UUID sessionId = UUID.fromString(sessionIdString);
+        attributes.put("sessionId", sessionId);
+      } catch (IllegalArgumentException e) { // UUID 형식이 잘못되었을 때 발생하는 예외
+        // 세션 ID 형식이 유효하지 않으면 연결 거부
+        return false;
       }
 
       // Spring Security의 인증 정보를 WebSocket 세션으로 전달

--- a/src/main/java/com/example/mentoring/chat/config/ChatHandshakeInterceptor.java
+++ b/src/main/java/com/example/mentoring/chat/config/ChatHandshakeInterceptor.java
@@ -1,0 +1,50 @@
+package com.example.mentoring.chat.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import java.util.Map;
+
+@Component
+public class ChatHandshakeInterceptor implements HandshakeInterceptor {
+
+  @Override
+  public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+      WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+    if (request instanceof ServletServerHttpRequest) {
+      ServletServerHttpRequest servletRequest = (ServletServerHttpRequest) request;
+      HttpServletRequest httpRequest = servletRequest.getServletRequest();
+
+      // URL에서 PathVariable (sessionId) 추출
+      String path = httpRequest.getRequestURI();
+      String[] pathSegments = path.split("/");
+      String sessionId = pathSegments[pathSegments.length - 1];
+
+      try {
+        attributes.put("sessionId", Integer.parseInt(sessionId));
+      } catch (NumberFormatException e) {
+        return false; // 세션 ID가 숫자가 아니면 연결 거부
+      }
+
+      // Spring Security의 인증 정보를 WebSocket 세션으로 전달
+      if (request.getPrincipal() != null) {
+        attributes.put("userPrincipal", request.getPrincipal());
+      } else {
+        // 인증되지 않은 사용자는 연결 거부
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+      WebSocketHandler wsHandler, Exception exception) {
+    // 핸드쉐이크 후 처리 (비워둠)
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/example/mentoring/chat/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.example.mentoring.chat.config;
+
+import com.example.mentoring.chat.handler.ChatWebSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+  private final ChatWebSocketHandler chatWebSocketHandler;
+  private final ChatHandshakeInterceptor chatHandshakeInterceptor;
+
+  @Override
+  public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+    registry.addHandler(chatWebSocketHandler, "/ws/chat/{sessionId}") // 웹소켓 연결 주소
+        .addInterceptors(chatHandshakeInterceptor)
+        .setAllowedOrigins("*");
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/controller/ChatController.java
+++ b/src/main/java/com/example/mentoring/chat/controller/ChatController.java
@@ -1,0 +1,68 @@
+package com.example.mentoring.chat.controller;
+
+import com.example.mentoring.auth.service.AuthService;
+import com.example.mentoring.auth.service.CustomUserDetails;
+import com.example.mentoring.chat.dto.ChatMessageRequest;
+import com.example.mentoring.chat.dto.ChatMessageResponse;
+import com.example.mentoring.chat.dto.ChatRoomResponse;
+import com.example.mentoring.chat.service.ChatService;
+import com.example.mentoring.member.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+  private final ChatService chatService;
+  private final AuthService authService;
+
+  // 채팅방 목록 조회
+  @GetMapping("/my")
+  public ResponseEntity<List<ChatRoomResponse>> getMyChatRooms() {
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    List<ChatRoomResponse> responses = chatService.getMyChatRooms(currentUser.getUserId());
+    return ResponseEntity.ok(responses);
+  }
+
+  // 특정 채팅방 조회
+  @GetMapping("/{sessionId}")
+  public ResponseEntity<ChatRoomResponse> getChatRoom(
+      @PathVariable Integer sessionId) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    ChatRoomResponse response = chatService.getChatRoom(sessionId, currentUser.getUserId());
+    return ResponseEntity.ok(response);
+  }
+
+  // 채팅 메시지 목록 조회
+  @GetMapping("/{sessionId}/messages")
+  public ResponseEntity<List<ChatMessageResponse>> getMessages(
+      @PathVariable Integer sessionId) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    List<ChatMessageResponse> responses = chatService.getMessages(sessionId, currentUser.getUserId());
+    return ResponseEntity.ok(responses);
+  }
+
+  // 메시지 읽음 처리
+  @PatchMapping("/{sessionId}/read")
+  public ResponseEntity<Void> markMessagesAsRead(
+      @PathVariable Integer sessionId) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    chatService.markMessagesAsRead(sessionId, currentUser.getUserId());
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/controller/ChatController.java
+++ b/src/main/java/com/example/mentoring/chat/controller/ChatController.java
@@ -7,6 +7,7 @@ import com.example.mentoring.chat.dto.ChatMessageResponse;
 import com.example.mentoring.chat.dto.ChatRoomResponse;
 import com.example.mentoring.chat.service.ChatService;
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -39,7 +40,7 @@ public class ChatController {
   // 특정 채팅방 조회
   @GetMapping("/{sessionId}")
   public ResponseEntity<ChatRoomResponse> getChatRoom(
-      @PathVariable Integer sessionId) {
+      @PathVariable UUID sessionId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
     ChatRoomResponse response = chatService.getChatRoom(sessionId, currentUser.getUserId());
@@ -49,7 +50,7 @@ public class ChatController {
   // 채팅 메시지 목록 조회
   @GetMapping("/{sessionId}/messages")
   public ResponseEntity<List<ChatMessageResponse>> getMessages(
-      @PathVariable Integer sessionId) {
+      @PathVariable UUID sessionId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
     List<ChatMessageResponse> responses = chatService.getMessages(sessionId, currentUser.getUserId());
@@ -59,7 +60,7 @@ public class ChatController {
   // 메시지 읽음 처리
   @PatchMapping("/{sessionId}/read")
   public ResponseEntity<Void> markMessagesAsRead(
-      @PathVariable Integer sessionId) {
+      @PathVariable UUID sessionId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
     chatService.markMessagesAsRead(sessionId, currentUser.getUserId());

--- a/src/main/java/com/example/mentoring/chat/dto/ChatMessageRequest.java
+++ b/src/main/java/com/example/mentoring/chat/dto/ChatMessageRequest.java
@@ -1,0 +1,14 @@
+package com.example.mentoring.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageRequest {
+  // 채팅 메시지 전송 요청 DTO
+
+  private String content;
+}

--- a/src/main/java/com/example/mentoring/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/example/mentoring/chat/dto/ChatMessageResponse.java
@@ -1,0 +1,37 @@
+package com.example.mentoring.chat.dto;
+
+import com.example.mentoring.chat.entity.ChatMessage;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageResponse {
+  // 채팅 메시지 응답 DTO
+
+  private Integer id;
+  private Integer sessionId;
+  private Integer senderId;
+  private String senderNickname;
+  private String content;
+  private LocalDateTime sendAt;
+  private Boolean isRead;
+
+  public static ChatMessageResponse from(ChatMessage message) {
+    return ChatMessageResponse.builder()
+        .id(message.getId())
+        .sessionId(message.getChatRoom().getSessionId())
+        .senderId(message.getSender().getId())
+        .senderNickname(message.getSender().getNickname())
+        .content(message.getContent())
+        .sendAt(message.getSendAt())
+        .isRead(message.getIsRead())
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/dto/ChatMessageResponse.java
+++ b/src/main/java/com/example/mentoring/chat/dto/ChatMessageResponse.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.chat.dto;
 
 import com.example.mentoring.chat.entity.ChatMessage;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,9 +16,9 @@ import java.time.LocalDateTime;
 public class ChatMessageResponse {
   // 채팅 메시지 응답 DTO
 
-  private Integer id;
-  private Integer sessionId;
-  private Integer senderId;
+  private UUID id;
+  private UUID sessionId;
+  private UUID senderId;
   private String senderNickname;
   private String content;
   private LocalDateTime sendAt;

--- a/src/main/java/com/example/mentoring/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/example/mentoring/chat/dto/ChatRoomResponse.java
@@ -5,6 +5,7 @@ import com.example.mentoring.chat.entity.ChatRoom;
 import com.example.mentoring.match.entity.Session;
 import com.example.mentoring.member.entity.User;
 import java.util.List;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,7 +21,7 @@ import java.time.LocalDateTime;
 public class ChatRoomResponse {
   // 채팅방 응답 DTO
 
-  private Integer sessionId;
+  private UUID sessionId;
   private Boolean isLocked;
   private String partnerNickname;
   private String lastMessage;

--- a/src/main/java/com/example/mentoring/chat/dto/ChatRoomResponse.java
+++ b/src/main/java/com/example/mentoring/chat/dto/ChatRoomResponse.java
@@ -1,0 +1,54 @@
+package com.example.mentoring.chat.dto;
+
+import com.example.mentoring.chat.entity.ChatMessage;
+import com.example.mentoring.chat.entity.ChatRoom;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.member.entity.User;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomResponse {
+  // 채팅방 응답 DTO
+
+  private Integer sessionId;
+  private Boolean isLocked;
+  private String partnerNickname;
+  private String lastMessage;
+  private LocalDateTime lastMessageTime;
+  private Long unreadCount;
+  private LocalDateTime createdAt;
+
+  // unreadCount는 Repository에서 가져와야 하므로 인자로 받음
+  public static ChatRoomResponse of(ChatRoom chatRoom, User currentUser, Long unreadCount) {
+    Session session = chatRoom.getSession();
+    User partner = session.getMentor().getId().equals(currentUser.getId())
+        ? session.getMentee()
+        : session.getMentor();
+
+    // 마지막 메시지 추출
+    List<ChatMessage> messages = chatRoom.getMessages();
+    ChatMessage lastMsg = (messages != null && !messages.isEmpty())
+        ? messages.get(messages.size() - 1)
+        : null;
+
+    return ChatRoomResponse.builder()
+        .sessionId(chatRoom.getSessionId())
+        .isLocked(chatRoom.getIsLocked())
+        .partnerNickname(partner.getNickname())
+        .lastMessage(lastMsg != null ? lastMsg.getContent() : null)
+        .lastMessageTime(lastMsg != null ? lastMsg.getSendAt() : null)
+        .unreadCount(unreadCount)
+        .createdAt(chatRoom.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/mentoring/chat/entity/ChatMessage.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,9 +27,11 @@ import java.time.LocalDateTime;
 @Builder
 public class ChatMessage {
 
+  // 병목 해결 위해 UUID 채용
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(columnDefinition = "BINARY(16)")
+  private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "chat_room_session_id", nullable = false)

--- a/src/main/java/com/example/mentoring/chat/entity/ChatMessage.java
+++ b/src/main/java/com/example/mentoring/chat/entity/ChatMessage.java
@@ -1,0 +1,56 @@
+package com.example.mentoring.chat.entity;
+
+import com.example.mentoring.member.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "chat_room_session_id", nullable = false)
+  private ChatRoom chatRoom;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sender_user_id", nullable = false)
+  private User sender;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime sendAt;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean isRead = false;
+
+  // 비즈니스 메서드
+  public void markAsRead() {
+    this.isRead = true;
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/mentoring/chat/entity/ChatRoom.java
@@ -1,0 +1,64 @@
+package com.example.mentoring.chat.entity;
+
+import com.example.mentoring.match.entity.Session;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "chat_room")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoom {
+
+  @Id
+  private Integer sessionId;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @MapsId
+  @JoinColumn(name = "session_id")
+  private Session session;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean isLocked = false;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<ChatMessage> messages = new ArrayList<>();
+
+  // 비즈니스 메서드
+  public void lock() {
+    this.isLocked = true;
+  }
+
+  public void unlock() {
+    this.isLocked = false;
+  }
+
+  public boolean canSendMessage() {
+    return !this.isLocked;
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/entity/ChatRoom.java
+++ b/src/main/java/com/example/mentoring/chat/entity/ChatRoom.java
@@ -11,6 +11,7 @@ import jakarta.persistence.MapsId;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,7 +31,7 @@ import java.util.List;
 public class ChatRoom {
 
   @Id
-  private Integer sessionId;
+  private UUID sessionId;
 
   @OneToOne(fetch = FetchType.LAZY)
   @MapsId

--- a/src/main/java/com/example/mentoring/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/example/mentoring/chat/handler/ChatWebSocketHandler.java
@@ -8,6 +8,7 @@ import com.example.mentoring.chat.service.RedisPublisher;
 import com.example.mentoring.member.entity.User;
 import com.example.mentoring.member.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -33,11 +34,11 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
   private final RedisPublisher redisPublisher;
 
   // sessionId -> Map<WebSocketSessionId, WebSocketSession>
-  private final Map<Integer, Map<String, WebSocketSession>> chatRooms = new ConcurrentHashMap<>();
+  private final Map<UUID, Map<String, WebSocketSession>> chatRooms = new ConcurrentHashMap<>();
 
   @Override
   public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-    Integer sessionId = (Integer) session.getAttributes().get("sessionId");
+    UUID sessionId = (UUID) session.getAttributes().get("sessionId");
     User user = getUserFromSession(session);
 
     if (user == null || sessionId == null) {
@@ -56,7 +57,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
   @Override
   protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-    Integer sessionId = (Integer) session.getAttributes().get("sessionId");
+    UUID sessionId = (UUID) session.getAttributes().get("sessionId");
     User user = getUserFromSession(session);
 
     if (user == null) return; // 방어 코드
@@ -72,7 +73,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
 
   @Override
   public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-    Integer sessionId = (Integer) session.getAttributes().get("sessionId");
+    UUID sessionId = (UUID) session.getAttributes().get("sessionId");
 
     if (sessionId != null) {
       log.info("WebSocket 연결 종료: sessionId={}", sessionId);
@@ -86,7 +87,7 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     }
   }
 
-  private void broadcastMessage(Integer sessionId, ChatMessageResponse message) {
+  private void broadcastMessage(UUID sessionId, ChatMessageResponse message) {
     Map<String, WebSocketSession> sessions = chatRooms.get(sessionId);
     if (sessions == null) return;
 

--- a/src/main/java/com/example/mentoring/chat/handler/ChatWebSocketHandler.java
+++ b/src/main/java/com/example/mentoring/chat/handler/ChatWebSocketHandler.java
@@ -1,0 +1,124 @@
+package com.example.mentoring.chat.handler;
+
+import com.example.mentoring.auth.service.CustomUserDetails;
+import com.example.mentoring.chat.dto.ChatMessageRequest;
+import com.example.mentoring.chat.dto.ChatMessageResponse;
+import com.example.mentoring.chat.service.ChatService;
+import com.example.mentoring.chat.service.RedisPublisher;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatWebSocketHandler extends TextWebSocketHandler {
+
+  private final ChatService chatService;
+  private final ObjectMapper objectMapper;
+  private final UserRepository userRepository;
+  private final RedisPublisher redisPublisher;
+
+  // sessionId -> Map<WebSocketSessionId, WebSocketSession>
+  private final Map<Integer, Map<String, WebSocketSession>> chatRooms = new ConcurrentHashMap<>();
+
+  @Override
+  public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+    Integer sessionId = (Integer) session.getAttributes().get("sessionId");
+    User user = getUserFromSession(session);
+
+    if (user == null || sessionId == null) {
+      session.close(CloseStatus.BAD_DATA);
+      return;
+    }
+
+    log.info("WebSocket 연결 수립: sessionId={}, userId={}, nickname={}", sessionId, user.getId(), user.getNickname());
+
+    chatRooms.computeIfAbsent(sessionId, k -> new ConcurrentHashMap<>())
+        .put(session.getId(), session);
+
+    // 연결 시 읽음 처리
+    chatService.markMessagesAsRead(sessionId, user.getId());
+  }
+
+  @Override
+  protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+    Integer sessionId = (Integer) session.getAttributes().get("sessionId");
+    User user = getUserFromSession(session);
+
+    if (user == null) return; // 방어 코드
+
+    String payload = message.getPayload();
+    ChatMessageRequest request = objectMapper.readValue(payload, ChatMessageRequest.class);
+
+    // 메시지 저장 및 DB 처리
+    ChatMessageResponse response = chatService.sendMessage(sessionId, user.getId(), request);
+
+    redisPublisher.publish(response);
+  }
+
+  @Override
+  public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+    Integer sessionId = (Integer) session.getAttributes().get("sessionId");
+
+    if (sessionId != null) {
+      log.info("WebSocket 연결 종료: sessionId={}", sessionId);
+      Map<String, WebSocketSession> sessions = chatRooms.get(sessionId);
+      if (sessions != null) {
+        sessions.remove(session.getId());
+        if (sessions.isEmpty()) {
+          chatRooms.remove(sessionId);
+        }
+      }
+    }
+  }
+
+  private void broadcastMessage(Integer sessionId, ChatMessageResponse message) {
+    Map<String, WebSocketSession> sessions = chatRooms.get(sessionId);
+    if (sessions == null) return;
+
+    String messageJson;
+    try {
+      messageJson = objectMapper.writeValueAsString(message);
+    } catch (Exception e) {
+      log.error("메시지 직렬화 실패", e);
+      return;
+    }
+
+    sessions.values().forEach(session -> {
+      try {
+        if (session.isOpen()) {
+          session.sendMessage(new TextMessage(messageJson));
+        }
+      } catch (IOException e) {
+        log.error("메시지 전송 실패: sessionId={}", session.getId(), e);
+      }
+    });
+  }
+
+  private User getUserFromSession(WebSocketSession session) {
+    // Interceptor에서 넣어준 Principal 추출
+    Principal principal = (Principal) session.getAttributes().get("userPrincipal");
+
+    if (principal instanceof UsernamePasswordAuthenticationToken) {
+      CustomUserDetails userDetails = (CustomUserDetails) ((UsernamePasswordAuthenticationToken) principal).getPrincipal();
+      // DB에서 최신 유저 정보 조회 (for 영속성 컨텍스트 관리)
+      return userRepository.findById(userDetails.getUserId()).orElse(null);
+    }
+
+    return null;
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/mentoring/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,22 @@
+package com.example.mentoring.chat.repository;
+
+import com.example.mentoring.chat.entity.ChatMessage;
+import com.example.mentoring.chat.entity.ChatRoom;
+import com.example.mentoring.member.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Integer> {
+
+  // 채팅방의 메시지를 시간순으로 조회
+  List<ChatMessage> findByChatRoomOrderBySendAtAsc(ChatRoom chatRoom);
+
+  //읽지 않은 메시지 조회 (상대방이 보낸 메시지 중 읽지 않은 것)
+  List<ChatMessage> findByChatRoomAndSenderNotAndIsReadFalse(ChatRoom chatRoom, User user);
+
+  //읽지 않은 메시지 개수 조회
+  Long countByChatRoomAndSenderNotAndIsReadFalse(ChatRoom chatRoom, User user);
+}

--- a/src/main/java/com/example/mentoring/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/example/mentoring/chat/repository/ChatMessageRepository.java
@@ -3,13 +3,14 @@ package com.example.mentoring.chat.repository;
 import com.example.mentoring.chat.entity.ChatMessage;
 import com.example.mentoring.chat.entity.ChatRoom;
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ChatMessageRepository extends JpaRepository<ChatMessage, Integer> {
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, UUID> {
 
   // 채팅방의 메시지를 시간순으로 조회
   List<ChatMessage> findByChatRoomOrderBySendAtAsc(ChatRoom chatRoom);

--- a/src/main/java/com/example/mentoring/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/mentoring/chat/repository/ChatRoomRepository.java
@@ -2,13 +2,14 @@ package com.example.mentoring.chat.repository;
 
 import com.example.mentoring.chat.entity.ChatRoom;
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Integer> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, UUID> {
 
   //내가 참여 중인 세션의 채팅방 목록 조회 (생성일 최신순)
   List<ChatRoom> findBySession_MentorOrSession_MenteeOrderByCreatedAtDesc(User mentor, User mentee);

--- a/src/main/java/com/example/mentoring/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/example/mentoring/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,15 @@
+package com.example.mentoring.chat.repository;
+
+import com.example.mentoring.chat.entity.ChatRoom;
+import com.example.mentoring.member.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Integer> {
+
+  //내가 참여 중인 세션의 채팅방 목록 조회 (생성일 최신순)
+  List<ChatRoom> findBySession_MentorOrSession_MenteeOrderByCreatedAtDesc(User mentor, User mentee);
+}

--- a/src/main/java/com/example/mentoring/chat/service/ChatService.java
+++ b/src/main/java/com/example/mentoring/chat/service/ChatService.java
@@ -1,0 +1,148 @@
+package com.example.mentoring.chat.service;
+
+import com.example.mentoring.chat.dto.ChatMessageRequest;
+import com.example.mentoring.chat.dto.ChatMessageResponse;
+import com.example.mentoring.chat.dto.ChatRoomResponse;
+import com.example.mentoring.chat.entity.ChatMessage;
+import com.example.mentoring.chat.entity.ChatRoom;
+import com.example.mentoring.chat.repository.ChatMessageRepository;
+import com.example.mentoring.chat.repository.ChatRoomRepository;
+import com.example.mentoring.match.event.SessionCreatedEvent;
+import com.example.mentoring.match.event.SessionCompletedEvent;
+import org.springframework.context.event.EventListener;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+
+  private final ChatRoomRepository chatRoomRepository;
+  private final ChatMessageRepository chatMessageRepository;
+  private final UserRepository userRepository;
+
+  // 세션 생성 이벤트를 받아서 채팅방 생성
+  @EventListener
+  @Transactional
+  public void handleSessionCreated(SessionCreatedEvent event) {
+    createChatRoom(event.getSession());
+  }
+
+  // 세션 종료 이벤트를 받아서 채팅방 잠금
+  @EventListener
+  @Transactional
+  public void handleSessionCompleted(SessionCompletedEvent event) {
+    lockChatRoom(event.getSession().getId());
+  }
+
+  @Transactional
+  public ChatRoom createChatRoom(Session session) {
+    if (chatRoomRepository.existsById(session.getId())) {
+      return chatRoomRepository.findById(session.getId()).get();
+    }
+
+    ChatRoom chatRoom = ChatRoom.builder().session(session).build();
+    return chatRoomRepository.save(chatRoom);
+  }
+
+  public ChatRoomResponse getChatRoom(Integer sessionId, Integer userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    ChatRoom chatRoom = chatRoomRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+    if (!chatRoom.getSession().isParticipant(user)) {
+      throw new IllegalStateException("채팅방 참여자만 조회할 수 있습니다.");
+    }
+
+    Long unreadCount = chatMessageRepository.countByChatRoomAndSenderNotAndIsReadFalse(chatRoom, user);
+    return ChatRoomResponse.of(chatRoom, user, unreadCount);
+  }
+
+  public List<ChatRoomResponse> getMyChatRooms(Integer userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    return chatRoomRepository.findBySession_MentorOrSession_MenteeOrderByCreatedAtDesc(user, user).stream()
+        .map(chatRoom -> {
+          Long unreadCount = chatMessageRepository.countByChatRoomAndSenderNotAndIsReadFalse(chatRoom, user);
+          return ChatRoomResponse.of(chatRoom, user, unreadCount);
+        })
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public ChatMessageResponse sendMessage(Integer sessionId, Integer userId, ChatMessageRequest request) {
+    User sender = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    ChatRoom chatRoom = chatRoomRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+    if (!chatRoom.getSession().isParticipant(sender)) {
+      throw new IllegalStateException("채팅방 참여자만 메시지를 보낼 수 있습니다.");
+    }
+
+    if (!chatRoom.canSendMessage()) {
+      throw new IllegalStateException("잠긴 채팅방에는 메시지를 보낼 수 없습니다.");
+    }
+
+    ChatMessage message = ChatMessage.builder()
+        .chatRoom(chatRoom)
+        .sender(sender)
+        .content(request.getContent())
+        .build();
+
+    ChatMessage savedMessage = chatMessageRepository.save(message);
+    return ChatMessageResponse.from(savedMessage);
+  }
+
+  public List<ChatMessageResponse> getMessages(Integer sessionId, Integer userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    ChatRoom chatRoom = chatRoomRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+    if (!chatRoom.getSession().isParticipant(user)) {
+      throw new IllegalStateException("채팅방 참여자만 메시지를 조회할 수 있습니다.");
+    }
+
+    return chatMessageRepository.findByChatRoomOrderBySendAtAsc(chatRoom).stream()
+        .map(ChatMessageResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public void markMessagesAsRead(Integer sessionId, Integer userId) {
+    User reader = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    ChatRoom chatRoom = chatRoomRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+
+    if (!chatRoom.getSession().isParticipant(reader)) {
+      throw new IllegalStateException("채팅방 참여자만 읽음 처리할 수 있습니다.");
+    }
+
+    List<ChatMessage> unreadMessages = chatMessageRepository.findByChatRoomAndSenderNotAndIsReadFalse(chatRoom, reader);
+    unreadMessages.forEach(ChatMessage::markAsRead);
+  }
+
+  @Transactional
+  public void lockChatRoom(Integer sessionId) {
+    ChatRoom chatRoom = chatRoomRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
+    chatRoom.lock();
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/service/ChatService.java
+++ b/src/main/java/com/example/mentoring/chat/service/ChatService.java
@@ -9,6 +9,7 @@ import com.example.mentoring.chat.repository.ChatMessageRepository;
 import com.example.mentoring.chat.repository.ChatRoomRepository;
 import com.example.mentoring.match.event.SessionCreatedEvent;
 import com.example.mentoring.match.event.SessionCompletedEvent;
+import java.util.UUID;
 import org.springframework.context.event.EventListener;
 import com.example.mentoring.match.entity.Session;
 import com.example.mentoring.member.entity.User;
@@ -54,7 +55,7 @@ public class ChatService {
     return chatRoomRepository.save(chatRoom);
   }
 
-  public ChatRoomResponse getChatRoom(Integer sessionId, Integer userId) {
+  public ChatRoomResponse getChatRoom(UUID sessionId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -69,7 +70,7 @@ public class ChatService {
     return ChatRoomResponse.of(chatRoom, user, unreadCount);
   }
 
-  public List<ChatRoomResponse> getMyChatRooms(Integer userId) {
+  public List<ChatRoomResponse> getMyChatRooms(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -82,7 +83,7 @@ public class ChatService {
   }
 
   @Transactional
-  public ChatMessageResponse sendMessage(Integer sessionId, Integer userId, ChatMessageRequest request) {
+  public ChatMessageResponse sendMessage(UUID sessionId, UUID userId, ChatMessageRequest request) {
     User sender = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -107,7 +108,7 @@ public class ChatService {
     return ChatMessageResponse.from(savedMessage);
   }
 
-  public List<ChatMessageResponse> getMessages(Integer sessionId, Integer userId) {
+  public List<ChatMessageResponse> getMessages(UUID sessionId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -124,7 +125,7 @@ public class ChatService {
   }
 
   @Transactional
-  public void markMessagesAsRead(Integer sessionId, Integer userId) {
+  public void markMessagesAsRead(UUID sessionId, UUID userId) {
     User reader = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -140,7 +141,7 @@ public class ChatService {
   }
 
   @Transactional
-  public void lockChatRoom(Integer sessionId) {
+  public void lockChatRoom(UUID sessionId) {
     ChatRoom chatRoom = chatRoomRepository.findById(sessionId)
         .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
     chatRoom.lock();

--- a/src/main/java/com/example/mentoring/chat/service/RedisPublisher.java
+++ b/src/main/java/com/example/mentoring/chat/service/RedisPublisher.java
@@ -1,0 +1,19 @@
+package com.example.mentoring.chat.service;
+
+import com.example.mentoring.chat.dto.ChatMessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisPublisher {
+
+  private final RedisTemplate<String, Object> redisTemplate;
+  private final ChannelTopic channelTopic;
+
+  public void publish(ChatMessageResponse message) {
+    redisTemplate.convertAndSend(channelTopic.getTopic(), message);
+  }
+}

--- a/src/main/java/com/example/mentoring/chat/service/RedisSubscriber.java
+++ b/src/main/java/com/example/mentoring/chat/service/RedisSubscriber.java
@@ -1,0 +1,29 @@
+package com.example.mentoring.chat.service;
+
+import com.example.mentoring.chat.dto.ChatMessageResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisSubscriber {
+
+  private final ObjectMapper objectMapper;
+
+  public void sendMessage(String publishMessage) {
+    try {
+      // 레디스에서 온 JSON 문자열을 DTO로 변환
+      ChatMessageResponse message = objectMapper.readValue(publishMessage, ChatMessageResponse.class);
+
+      // 현재 서버에 접속해 있는 WebSocket 세션들에게 전송
+      log.info("Redis Sub message: {}", message.getContent());
+
+    } catch (Exception e) {
+      log.error("메시지 수신 실패", e);
+    }
+  }
+}

--- a/src/main/java/com/example/mentoring/global/config/RedisConfig.java
+++ b/src/main/java/com/example/mentoring/global/config/RedisConfig.java
@@ -1,0 +1,60 @@
+package com.example.mentoring.global.config;
+
+import com.example.mentoring.chat.service.RedisSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public ChannelTopic channelTopic() {
+    return new ChannelTopic("chatroom");
+  }
+
+  // Redis Pub/Sub 메시지 처리 리스너 컨테이너
+  @Bean
+  public RedisMessageListenerContainer redisMessageListener(
+      RedisConnectionFactory connectionFactory,
+      MessageListenerAdapter listenerAdapter,
+      ChannelTopic channelTopic) {
+
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    container.addMessageListener(listenerAdapter, channelTopic);
+    return container;
+  }
+
+  // 실제 메시지 처리 리스너 어댑터
+  @Bean
+  public MessageListenerAdapter listenerAdapter(RedisSubscriber subscriber) {
+    return new MessageListenerAdapter(subscriber, "sendMessage");
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(connectionFactory);
+
+    ObjectMapper objectMapper = new ObjectMapper();
+    objectMapper.registerModule(new JavaTimeModule());
+
+    Jackson2JsonRedisSerializer<Object> jackson2JsonRedisSerializer =
+        new Jackson2JsonRedisSerializer<>(objectMapper, Object.class);
+
+    // Key는 String, Value는 JSON으로 직렬화
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+
+    return redisTemplate;
+  }
+}

--- a/src/main/java/com/example/mentoring/global/util/JwtUtil.java
+++ b/src/main/java/com/example/mentoring/global/util/JwtUtil.java
@@ -8,6 +8,7 @@ import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -35,7 +36,7 @@ public class JwtUtil {
   }
 
   // Access Token 생성
-  public String createAccessToken(Integer userId, String email, User.Role role) {
+  public String createAccessToken(UUID userId, String email, User.Role role) {
     Date now = new Date();
     Date validity = new Date(now.getTime() + accessTokenValidityInMilliseconds);
 
@@ -50,7 +51,7 @@ public class JwtUtil {
   }
 
   // Refresh Token 생성
-  public String createRefreshToken(Integer userId) {
+  public String createRefreshToken(UUID userId) {
     Date now = new Date();
     Date validity = new Date(now.getTime() + refreshTokenValidityInMilliseconds);
 

--- a/src/main/java/com/example/mentoring/match/controller/ApplicationController.java
+++ b/src/main/java/com/example/mentoring/match/controller/ApplicationController.java
@@ -8,6 +8,7 @@ import com.example.mentoring.match.dto.CreateApplicationRequest;
 import com.example.mentoring.match.dto.UpdateApplicationRequest;
 import com.example.mentoring.match.service.ApplicationService;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 
@@ -45,7 +46,7 @@ public class ApplicationController {
   // 신청서 수정
   @PutMapping("/{applicationId}")
   public ResponseEntity<ApplicationResponse> updateApplication(
-      @PathVariable Integer applicationId,
+      @PathVariable UUID applicationId,
       @Valid @RequestBody UpdateApplicationRequest request) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
@@ -57,7 +58,7 @@ public class ApplicationController {
   // 신청서 삭제
   @DeleteMapping("/{applicationId}")
   public ResponseEntity<Void> deleteApplication(
-      @PathVariable Integer applicationId) {
+      @PathVariable UUID applicationId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
 
@@ -68,7 +69,7 @@ public class ApplicationController {
   // 신청서 상세 조회
   @GetMapping("/{applicationId}")
   public ResponseEntity<ApplicationResponse> getApplication(
-      @PathVariable Integer applicationId) {
+      @PathVariable UUID applicationId) {
     ApplicationResponse response = applicationService.getApplication(applicationId);
     return ResponseEntity.ok(response);
   }
@@ -97,7 +98,7 @@ public class ApplicationController {
   // 신청 승인 (멘토 전용)
   @PatchMapping("/mentor/{applicationId}/approve")
   public ResponseEntity<ApplicationResponse> approveApplication(
-      @PathVariable Integer applicationId) {
+      @PathVariable UUID applicationId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
 
@@ -108,7 +109,7 @@ public class ApplicationController {
   // 신청 거절 (멘토 전용)
   @PatchMapping("/mentor/{applicationId}/reject")
   public ResponseEntity<ApplicationResponse> rejectApplication(
-      @PathVariable Integer applicationId) {
+      @PathVariable UUID applicationId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
 

--- a/src/main/java/com/example/mentoring/match/controller/SessionController.java
+++ b/src/main/java/com/example/mentoring/match/controller/SessionController.java
@@ -1,0 +1,69 @@
+package com.example.mentoring.match.controller;
+
+import com.example.mentoring.auth.service.AuthService;
+import com.example.mentoring.auth.service.CustomUserDetails;
+import com.example.mentoring.match.dto.SessionResponse;
+import com.example.mentoring.match.dto.SessionSummaryResponse;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.service.SessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/session")
+@RequiredArgsConstructor
+public class SessionController {
+
+  private final SessionService sessionService;
+  private final AuthService authService;
+
+  // 세션 상세 조회
+  @GetMapping("/{sessionId}")
+  public ResponseEntity<SessionResponse> getSession(
+      @PathVariable Integer sessionId) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    SessionResponse response = sessionService.getSession(sessionId, currentUser.getUserId());
+    return ResponseEntity.ok(response);
+  }
+
+  // 내 세션 목록 조회
+  @GetMapping("/my")
+  public ResponseEntity<List<SessionSummaryResponse>> getMySessions(
+      @RequestParam(required = false) Integer status) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+
+    if (status != null) {
+      Session.SessionStatus sessionStatus = Session.SessionStatus.fromCode(status);
+      List<SessionSummaryResponse> responses = sessionService.getMySessionsByStatus(currentUser.getUserId(), sessionStatus);
+      return ResponseEntity.ok(responses);
+    }
+
+    List<SessionSummaryResponse> responses = sessionService.getMySessions(currentUser.getUserId());
+    return ResponseEntity.ok(responses);
+  }
+
+  // 멘토링 종료 요청
+  @PatchMapping("/{sessionId}/request-end")
+  public ResponseEntity<SessionResponse> requestEndSession(
+      @PathVariable Integer sessionId) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    SessionResponse response = sessionService.requestEndSession(sessionId, currentUser.getUserId());
+    return ResponseEntity.ok(response);
+  }
+
+  // 멘토링 종료 확인
+  @PatchMapping("/{sessionId}/confirm-end")
+  public ResponseEntity<SessionResponse> confirmEndSession(
+      @PathVariable Integer sessionId) {
+
+    CustomUserDetails currentUser = authService.getCurrentUser();
+    SessionResponse response = sessionService.confirmEndSession(sessionId, currentUser.getUserId());
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/example/mentoring/match/controller/SessionController.java
+++ b/src/main/java/com/example/mentoring/match/controller/SessionController.java
@@ -6,6 +6,7 @@ import com.example.mentoring.match.dto.SessionResponse;
 import com.example.mentoring.match.dto.SessionSummaryResponse;
 import com.example.mentoring.match.entity.Session;
 import com.example.mentoring.match.service.SessionService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -23,7 +24,7 @@ public class SessionController {
   // 세션 상세 조회
   @GetMapping("/{sessionId}")
   public ResponseEntity<SessionResponse> getSession(
-      @PathVariable Integer sessionId) {
+      @PathVariable UUID sessionId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
     SessionResponse response = sessionService.getSession(sessionId, currentUser.getUserId());
@@ -33,13 +34,13 @@ public class SessionController {
   // 내 세션 목록 조회
   @GetMapping("/my")
   public ResponseEntity<List<SessionSummaryResponse>> getMySessions(
-      @RequestParam(required = false) Integer status) {
+      @RequestParam(required = false) Session.SessionStatus status) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
 
     if (status != null) {
-      Session.SessionStatus sessionStatus = Session.SessionStatus.fromCode(status);
-      List<SessionSummaryResponse> responses = sessionService.getMySessionsByStatus(currentUser.getUserId(), sessionStatus);
+      // fromCode() 호출 로직 제거
+      List<SessionSummaryResponse> responses = sessionService.getMySessionsByStatus(currentUser.getUserId(), status);
       return ResponseEntity.ok(responses);
     }
 
@@ -50,7 +51,7 @@ public class SessionController {
   // 멘토링 종료 요청
   @PatchMapping("/{sessionId}/request-end")
   public ResponseEntity<SessionResponse> requestEndSession(
-      @PathVariable Integer sessionId) {
+      @PathVariable UUID sessionId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
     SessionResponse response = sessionService.requestEndSession(sessionId, currentUser.getUserId());
@@ -60,7 +61,7 @@ public class SessionController {
   // 멘토링 종료 확인
   @PatchMapping("/{sessionId}/confirm-end")
   public ResponseEntity<SessionResponse> confirmEndSession(
-      @PathVariable Integer sessionId) {
+      @PathVariable UUID sessionId) {
 
     CustomUserDetails currentUser = authService.getCurrentUser();
     SessionResponse response = sessionService.confirmEndSession(sessionId, currentUser.getUserId());

--- a/src/main/java/com/example/mentoring/match/dto/ApplicationResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/ApplicationResponse.java
@@ -3,6 +3,7 @@ package com.example.mentoring.match.dto;
 import com.example.mentoring.match.entity.Application;
 import com.example.mentoring.match.entity.Application.ApplicationStatus;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,14 +16,14 @@ import lombok.NoArgsConstructor;
 public class ApplicationResponse {
   // 신청서 목록 (상세) 응답 DTO
 
-  private Integer id;
+  private UUID id;
 
   // 어떤 글에 대한 신청인지
   private Integer postId;
   private String postTitle;
 
   // 누가 신청했는지 (멘토가 확인)
-  private Integer menteeId;
+  private UUID menteeId;
   private String menteeNickname;
 
   private String content;

--- a/src/main/java/com/example/mentoring/match/dto/ApplicationSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/ApplicationSummaryResponse.java
@@ -3,6 +3,7 @@ package com.example.mentoring.match.dto;
 import com.example.mentoring.match.entity.Application;
 import com.example.mentoring.match.entity.Application.ApplicationStatus;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,13 +16,12 @@ import lombok.NoArgsConstructor;
 public class ApplicationSummaryResponse {
   // 신청서 목록 응답 DTO (마이페이지용)
 
-  private Integer id;
+  private UUID id;
   private Integer postId;
   private String postTitle; // 클릭하면 해당 모집글로 이동
   private String mentorNickname;
   private String menteeNickname;
 
-  private ApplicationStatus status;
   private String statusDescription;
   private LocalDateTime appliedAt;
 
@@ -32,7 +32,6 @@ public class ApplicationSummaryResponse {
         .postTitle(application.getPost().getTitle())
         .mentorNickname(application.getPost().getUser().getNickname())
         .menteeNickname(application.getUser().getNickname())
-        .status(application.getStatus())
         .statusDescription(application.getStatus().getDescription())
         .appliedAt(application.getAppliedAt())
         .build();

--- a/src/main/java/com/example/mentoring/match/dto/PostResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/PostResponse.java
@@ -52,7 +52,7 @@ public class PostResponse {
             .levelName(post.getLevelCode().getDisplayName())
             .title(post.getTitle())
             .content(post.getContent())
-            .status(post.getStatus())
+            .status(post.isRecruiting())
             .tags(tagResponses)
             .createdAt(post.getCreatedAt())
             .updatedAt(post.getUpdatedAt())

--- a/src/main/java/com/example/mentoring/match/dto/PostSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/PostSummaryResponse.java
@@ -30,7 +30,7 @@ public class PostSummaryResponse {
         .fieldName(post.getFieldCode().getDisplayName())
         .levelName(post.getLevelCode().getDisplayName())
         .title(post.getTitle())
-        .status(post.getStatus())
+        .status(post.isRecruiting())
         .applicationCount(post.getApplications().size())
         .createdAt(post.getCreatedAt())
         .build();

--- a/src/main/java/com/example/mentoring/match/dto/SessionResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/SessionResponse.java
@@ -1,0 +1,48 @@
+package com.example.mentoring.match.dto;
+
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.entity.Session.SessionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionResponse {
+  // 세션 응답 DTO
+
+  private Integer id;
+  private SessionStatus status;
+  private String statusDescription;
+  private LocalDateTime startDate;
+  private LocalDateTime endDate;
+  private Boolean mentorConfirm;
+  private Boolean menteeConfirm;
+  private Integer mentorId;
+  private String mentorNickname;
+  private Integer menteeId;
+  private String menteeNickname;
+  private Integer applicationId;
+
+  public static SessionResponse from(Session session) {
+    return SessionResponse.builder()
+        .id(session.getId())
+        .status(session.getStatus())
+        .statusDescription(session.getStatus().getDescription())
+        .startDate(session.getStartDate())
+        .endDate(session.getEndDate())
+        .mentorConfirm(session.getMentorConfirm())
+        .menteeConfirm(session.getMenteeConfirm())
+        .mentorId(session.getMentor().getId())
+        .mentorNickname(session.getMentor().getNickname())
+        .menteeId(session.getMentee().getId())
+        .menteeNickname(session.getMentee().getNickname())
+        .applicationId(session.getApplication().getId())
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/match/dto/SessionResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/SessionResponse.java
@@ -1,7 +1,7 @@
 package com.example.mentoring.match.dto;
 
 import com.example.mentoring.match.entity.Session;
-import com.example.mentoring.match.entity.Session.SessionStatus;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,23 +16,21 @@ import java.time.LocalDateTime;
 public class SessionResponse {
   // 세션 응답 DTO
 
-  private Integer id;
-  private SessionStatus status;
+  private UUID sessionId;
   private String statusDescription;
   private LocalDateTime startDate;
   private LocalDateTime endDate;
   private Boolean mentorConfirm;
   private Boolean menteeConfirm;
-  private Integer mentorId;
+  private UUID mentorId;
   private String mentorNickname;
-  private Integer menteeId;
+  private UUID menteeId;
   private String menteeNickname;
-  private Integer applicationId;
+  private UUID applicationId;
 
   public static SessionResponse from(Session session) {
     return SessionResponse.builder()
-        .id(session.getId())
-        .status(session.getStatus())
+        .sessionId(session.getId())
         .statusDescription(session.getStatus().getDescription())
         .startDate(session.getStartDate())
         .endDate(session.getEndDate())

--- a/src/main/java/com/example/mentoring/match/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/SessionSummaryResponse.java
@@ -1,0 +1,39 @@
+package com.example.mentoring.match.dto;
+
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.entity.Session.SessionStatus;
+import com.example.mentoring.member.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SessionSummaryResponse {
+  // 세션 목록 응답 (간략) DTO
+  private Integer id;
+  private SessionStatus status;
+  private String statusDescription;
+  private String partnerNickname; // 상대방 닉네임
+  private LocalDateTime startDate;
+
+  // 상대방(Partner)을 계산해야 하므로 currentUser를 인자로 받음
+  public static SessionSummaryResponse of(Session session, User currentUser) {
+    User partner = session.getMentor().getId().equals(currentUser.getId())
+        ? session.getMentee()
+        : session.getMentor();
+
+    return SessionSummaryResponse.builder()
+        .id(session.getId())
+        .status(session.getStatus())
+        .statusDescription(session.getStatus().getDescription())
+        .partnerNickname(partner.getNickname())
+        .startDate(session.getStartDate())
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/match/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/SessionSummaryResponse.java
@@ -3,6 +3,7 @@ package com.example.mentoring.match.dto;
 import com.example.mentoring.match.entity.Session;
 import com.example.mentoring.match.entity.Session.SessionStatus;
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,8 +17,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class SessionSummaryResponse {
   // 세션 목록 응답 (간략) DTO
-  private Integer id;
-  private SessionStatus status;
+  private UUID sessionId;
   private String statusDescription;
   private String partnerNickname; // 상대방 닉네임
   private LocalDateTime startDate;
@@ -29,8 +29,7 @@ public class SessionSummaryResponse {
         : session.getMentor();
 
     return SessionSummaryResponse.builder()
-        .id(session.getId())
-        .status(session.getStatus())
+        .sessionId(session.getId())
         .statusDescription(session.getStatus().getDescription())
         .partnerNickname(partner.getNickname())
         .startDate(session.getStartDate())

--- a/src/main/java/com/example/mentoring/match/entity/Application.java
+++ b/src/main/java/com/example/mentoring/match/entity/Application.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -36,17 +37,18 @@ public class Application {
   @Getter
   @RequiredArgsConstructor
   public enum ApplicationStatus {
-    PENDING(0, "신청 접수"),
-    APPROVED(1, "신청 승인"),
-    REJECTED(2, "신청 거절");
+    PENDING("신청 접수"),
+    APPROVED("신청 승인"),
+    REJECTED("신청 거절");
 
-    private final int code;
     private final String description;
   }
 
+  // Session과 통일성을 위해 UUID로 변경
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(columnDefinition = "BINARY(16)")
+  private UUID id;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "post_id", nullable = false)
@@ -59,8 +61,8 @@ public class Application {
   @Column(nullable = false, columnDefinition = "TEXT")
   private String content;
 
-  // Enum 순서 변경 금지 (0:PENDING, 1:APPROVED, 2:REJECTED)
-  @Enumerated(EnumType.ORDINAL)
+  // 순서 대신 STRING으로 관리
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   @Builder.Default
   private ApplicationStatus status = ApplicationStatus.PENDING;

--- a/src/main/java/com/example/mentoring/match/entity/Session.java
+++ b/src/main/java/com/example/mentoring/match/entity/Session.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,42 +30,27 @@ import java.time.LocalDateTime;
 @Builder
 public class Session {
 
+  @Getter
   public enum SessionStatus {
-    PROGRESS(0, "멘토링 진행 중"),
-    END_REQUESTED(1, "멘토링 종료 요청"),
-    COMPLETED(2, "멘토링 종료");
+    PROGRESS("멘토링 진행 중"),
+    END_REQUESTED("멘토링 종료 요청"),
+    COMPLETED("멘토링 종료");
 
-    private final int code;
     private final String description;
 
-    SessionStatus(int code, String description) {
-      this.code = code;
+    SessionStatus(String description) {
       this.description = description;
-    }
-
-    public int getCode() {
-      return code;
-    }
-
-    public String getDescription() {
-      return description;
-    }
-
-    public static SessionStatus fromCode(int code) {
-      for (SessionStatus status : SessionStatus.values()) {
-        if (status.code == code) {
-          return status;
-        }
-      }
-      throw new IllegalArgumentException("유효하지 않은 세션 상태 코드입니다: " + code);
     }
   }
 
+  // Integer -> UUID 변경
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(columnDefinition = "BINARY(16)")
+  private UUID id;
 
-  @Enumerated(EnumType.ORDINAL)
+  // 순서 대신 STRING으로 관리
+  @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   @Builder.Default
   private SessionStatus status = SessionStatus.PROGRESS;

--- a/src/main/java/com/example/mentoring/match/entity/Session.java
+++ b/src/main/java/com/example/mentoring/match/entity/Session.java
@@ -1,0 +1,146 @@
+package com.example.mentoring.match.entity;
+
+import com.example.mentoring.member.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "session")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Session {
+
+  public enum SessionStatus {
+    PROGRESS(0, "멘토링 진행 중"),
+    END_REQUESTED(1, "멘토링 종료 요청"),
+    COMPLETED(2, "멘토링 종료");
+
+    private final int code;
+    private final String description;
+
+    SessionStatus(int code, String description) {
+      this.code = code;
+      this.description = description;
+    }
+
+    public int getCode() {
+      return code;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public static SessionStatus fromCode(int code) {
+      for (SessionStatus status : SessionStatus.values()) {
+        if (status.code == code) {
+          return status;
+        }
+      }
+      throw new IllegalArgumentException("유효하지 않은 세션 상태 코드입니다: " + code);
+    }
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @Enumerated(EnumType.ORDINAL)
+  @Column(nullable = false)
+  @Builder.Default
+  private SessionStatus status = SessionStatus.PROGRESS;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime startDate;
+
+  @Column
+  private LocalDateTime endDate;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean mentorConfirm = false;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private Boolean menteeConfirm = false;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "mentor_user_id", nullable = false)
+  private User mentor;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "mentee_user_id", nullable = false)
+  private User mentee;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "application_id", nullable = false, unique = true)
+  private Application application;
+
+  // 비즈니스 메서드
+  public void requestEnd(User requester) {
+    if (this.status != SessionStatus.PROGRESS) {
+      throw new IllegalStateException("진행 중인 멘토링만 종료 요청할 수 있습니다.");
+    }
+
+    this.status = SessionStatus.END_REQUESTED;
+
+    // 종료 요청자 확인 처리
+    if (requester.getId().equals(this.mentor.getId())) {
+      this.mentorConfirm = true;
+    } else if (requester.getId().equals(this.mentee.getId())) {
+      this.menteeConfirm = true;
+    } else {
+      throw new IllegalStateException("멘토링 참여자만 종료 요청할 수 있습니다.");
+    }
+  }
+
+  public void confirmEnd(User confirmer) {
+    if (this.status != SessionStatus.END_REQUESTED) {
+      throw new IllegalStateException("종료 요청 상태에서만 확인할 수 있습니다.");
+    }
+
+    // 상대방 확인 처리
+    if (confirmer.getId().equals(this.mentor.getId())) {
+      this.mentorConfirm = true;
+    } else if (confirmer.getId().equals(this.mentee.getId())) {
+      this.menteeConfirm = true;
+    } else {
+      throw new IllegalStateException("멘토링 참여자만 확인할 수 있습니다.");
+    }
+
+    // 양쪽 모두 확인하면 완료 처리
+    if (this.mentorConfirm && this.menteeConfirm) {
+      this.status = SessionStatus.COMPLETED;
+      this.endDate = LocalDateTime.now();
+    }
+  }
+
+  public boolean isParticipant(User user) {
+    return this.mentor.getId().equals(user.getId()) ||
+        this.mentee.getId().equals(user.getId());
+  }
+
+  public boolean isCompleted() {
+    return this.status == SessionStatus.COMPLETED;
+  }
+}

--- a/src/main/java/com/example/mentoring/match/event/ApplicationApprovedEvent.java
+++ b/src/main/java/com/example/mentoring/match/event/ApplicationApprovedEvent.java
@@ -1,0 +1,11 @@
+package com.example.mentoring.match.event;
+
+import com.example.mentoring.match.entity.Application;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApplicationApprovedEvent {
+  private final Application application;
+}

--- a/src/main/java/com/example/mentoring/match/event/SessionCompletedEvent.java
+++ b/src/main/java/com/example/mentoring/match/event/SessionCompletedEvent.java
@@ -1,0 +1,11 @@
+package com.example.mentoring.match.event;
+
+import com.example.mentoring.match.entity.Session;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SessionCompletedEvent {
+  private final Session session;
+}

--- a/src/main/java/com/example/mentoring/match/event/SessionCreatedEvent.java
+++ b/src/main/java/com/example/mentoring/match/event/SessionCreatedEvent.java
@@ -1,0 +1,11 @@
+package com.example.mentoring.match.event;
+
+import com.example.mentoring.match.entity.Session;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SessionCreatedEvent {
+  private final Session session;
+}

--- a/src/main/java/com/example/mentoring/match/repository/ApplicationRepository.java
+++ b/src/main/java/com/example/mentoring/match/repository/ApplicationRepository.java
@@ -3,6 +3,7 @@ package com.example.mentoring.match.repository;
 import com.example.mentoring.match.entity.Application;
 import com.example.mentoring.match.entity.Post;
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface ApplicationRepository extends JpaRepository<Application, Integer> {
+public interface ApplicationRepository extends JpaRepository<Application, UUID> {
 
   // 멘티 마이페이지: 내 신청서 조회 (어떤 멘토의 모집글에 신청했는지)
   @EntityGraph(attributePaths = {"post", "post.user"})

--- a/src/main/java/com/example/mentoring/match/repository/PostRepository.java
+++ b/src/main/java/com/example/mentoring/match/repository/PostRepository.java
@@ -21,7 +21,7 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 
   // 메인 게시판: 모집 중인 글(태그 매핑 + 실제 태그) 조회 + 작성자 정보 즉시 로딩
   @EntityGraph(attributePaths = {"user", "postTags", "postTags.tag"})
-  Page<Post> findByStatusTrueOrderByCreatedAtDesc(Pageable pageable);
+  Page<Post> findByIsRecruitingTrueOrderByCreatedAtDesc(Pageable pageable);
 
   // 상세 조회: 작성자와 태그들을 모두 한 번에 조회
   @EntityGraph(attributePaths = {"user", "postTags", "postTags.tag"})

--- a/src/main/java/com/example/mentoring/match/repository/SessionRepository.java
+++ b/src/main/java/com/example/mentoring/match/repository/SessionRepository.java
@@ -4,6 +4,7 @@ import com.example.mentoring.match.entity.Application;
 import com.example.mentoring.match.entity.Session;
 import com.example.mentoring.match.entity.Session.SessionStatus;
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface SessionRepository extends JpaRepository<Session, Integer> {
+public interface SessionRepository extends JpaRepository<Session, UUID> {
 
   // Application으로 세션 조회
   Optional<Session> findByApplication(Application application);

--- a/src/main/java/com/example/mentoring/match/repository/SessionRepository.java
+++ b/src/main/java/com/example/mentoring/match/repository/SessionRepository.java
@@ -1,0 +1,27 @@
+package com.example.mentoring.match.repository;
+
+import com.example.mentoring.match.entity.Application;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.entity.Session.SessionStatus;
+import com.example.mentoring.member.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SessionRepository extends JpaRepository<Session, Integer> {
+
+  // Application으로 세션 조회
+  Optional<Session> findByApplication(Application application);
+
+  // 내가 멘토이거나 멘티인 세션 목록 조회 (최신순)
+  List<Session> findByMentorOrMenteeOrderByStartDateDesc(User mentor, User mentee);
+
+  // 특정 상태이면서 내가 참여 중인 세션 조회 (최신순)
+  List<Session> findByMentorAndStatusOrMenteeAndStatusOrderByStartDateDesc(
+      User mentor, SessionStatus mentorStatus,
+      User mentee, SessionStatus menteeStatus
+  );
+}

--- a/src/main/java/com/example/mentoring/match/service/ApplicationService.java
+++ b/src/main/java/com/example/mentoring/match/service/ApplicationService.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.match.service;
 
 import com.example.mentoring.match.event.ApplicationApprovedEvent;
+import java.util.UUID;
 import org.springframework.context.ApplicationEventPublisher;
 import com.example.mentoring.match.dto.ApplicationResponse;
 import com.example.mentoring.match.dto.ApplicationSummaryResponse;
@@ -33,7 +34,7 @@ public class ApplicationService {
   private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
-  public ApplicationResponse createApplication(Integer postId, Integer userId, CreateApplicationRequest request) {
+  public ApplicationResponse createApplication(Integer postId, UUID userId, CreateApplicationRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -63,7 +64,7 @@ public class ApplicationService {
   }
 
   @Transactional
-  public ApplicationResponse updateApplication(Integer applicationId, Integer userId, UpdateApplicationRequest request) {
+  public ApplicationResponse updateApplication(UUID applicationId, UUID userId, UpdateApplicationRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -79,7 +80,7 @@ public class ApplicationService {
   }
 
   @Transactional
-  public void deleteApplication(Integer applicationId, Integer userId) {
+  public void deleteApplication(UUID applicationId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -93,14 +94,14 @@ public class ApplicationService {
     applicationRepository.delete(application);
   }
 
-  public ApplicationResponse getApplication(Integer applicationId) {
+  public ApplicationResponse getApplication(UUID applicationId) {
     Application application = applicationRepository.findById(applicationId)
         .orElseThrow(() -> new IllegalArgumentException("신청서를 찾을 수 없습니다."));
     return ApplicationResponse.from(application);
   }
 
   // 특정 모집글에 달린 신청서 목록 조회 (작성자=멘토만 가능)
-  public List<ApplicationResponse> getApplicationsByPost(Integer postId, Integer userId) {
+  public List<ApplicationResponse> getApplicationsByPost(Integer postId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -118,7 +119,7 @@ public class ApplicationService {
   }
 
   // 내가 쓴 신청서 목록 조회 (마이페이지)
-  public List<ApplicationSummaryResponse> getMyApplications(Integer userId) {
+  public List<ApplicationSummaryResponse> getMyApplications(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -128,7 +129,7 @@ public class ApplicationService {
   }
 
   @Transactional
-  public ApplicationResponse approveApplication(Integer applicationId, Integer userId) {
+  public ApplicationResponse approveApplication(UUID applicationId, UUID userId) {
     User mentor = userRepository.findById(userId) // userId는 곧 승인을 시도하는 멘토의 ID
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -147,7 +148,7 @@ public class ApplicationService {
   }
 
   @Transactional
-  public ApplicationResponse rejectApplication(Integer applicationId, Integer userId) {
+  public ApplicationResponse rejectApplication(UUID applicationId, UUID userId) {
     User mentor = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 

--- a/src/main/java/com/example/mentoring/match/service/ApplicationService.java
+++ b/src/main/java/com/example/mentoring/match/service/ApplicationService.java
@@ -1,5 +1,7 @@
 package com.example.mentoring.match.service;
 
+import com.example.mentoring.match.event.ApplicationApprovedEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import com.example.mentoring.match.dto.ApplicationResponse;
 import com.example.mentoring.match.dto.ApplicationSummaryResponse;
 import com.example.mentoring.match.dto.CreateApplicationRequest;
@@ -26,6 +28,9 @@ public class ApplicationService {
   private final ApplicationRepository applicationRepository;
   private final PostRepository postRepository;
   private final UserRepository userRepository; // User 조회를 위해 추가
+
+  // 멘토링 승인 시 이벤트 발생
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional
   public ApplicationResponse createApplication(Integer postId, Integer userId, CreateApplicationRequest request) {
@@ -134,7 +139,10 @@ public class ApplicationService {
       throw new IllegalStateException("본인의 게시글에 대한 신청서만 승인할 수 있습니다.");
     }
 
+    // 승인 처리 -> 이벤트 발행
     application.approve();
+    eventPublisher.publishEvent(new ApplicationApprovedEvent(application));
+
     return ApplicationResponse.from(application);
   }
 

--- a/src/main/java/com/example/mentoring/match/service/PostService.java
+++ b/src/main/java/com/example/mentoring/match/service/PostService.java
@@ -130,7 +130,7 @@ public class PostService {
 
   // 페이징 적용: 메인 페이지 조회
   public Page<PostResponse> getAllPosts(Pageable pageable) {
-    return postRepository.findByStatusTrueOrderByCreatedAtDesc(pageable)
+    return postRepository.findByIsRecruitingTrueOrderByCreatedAtDesc(pageable)
         .map(PostResponse::from);
   }
 

--- a/src/main/java/com/example/mentoring/match/service/SessionService.java
+++ b/src/main/java/com/example/mentoring/match/service/SessionService.java
@@ -1,0 +1,123 @@
+package com.example.mentoring.match.service;
+
+import com.example.mentoring.match.dto.SessionResponse;
+import com.example.mentoring.match.dto.SessionSummaryResponse;
+import com.example.mentoring.match.entity.Application;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.event.ApplicationApprovedEvent;
+import com.example.mentoring.match.event.SessionCompletedEvent;
+import com.example.mentoring.match.event.SessionCreatedEvent;
+import com.example.mentoring.match.repository.SessionRepository;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SessionService {
+
+  private final SessionRepository sessionRepository;
+  private final UserRepository userRepository;
+  private final ApplicationEventPublisher eventPublisher;
+
+  // 신청 승인 이벤트를 받아서 세션 실행
+  @EventListener
+  @Transactional
+  public void handleApplicationApproved(ApplicationApprovedEvent event) {
+    createSession(event.getApplication());
+  }
+
+  @Transactional
+  public Session createSession(Application application) {
+    if (sessionRepository.findByApplication(application).isPresent()) {
+      // 이벤트 중복 수신 등의 케이스 방어
+      return sessionRepository.findByApplication(application).get();
+    }
+
+    Session session = Session.builder()
+        .application(application)
+        .mentor(application.getPost().getUser())
+        .mentee(application.getUser())
+        .build();
+
+    Session savedSession = sessionRepository.save(session);
+
+    // 이벤트 발행 -> ChatService로 토스
+    eventPublisher.publishEvent(new SessionCreatedEvent(savedSession));
+
+    return savedSession;
+  }
+
+  public SessionResponse getSession(Integer sessionId, Integer userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    Session session = sessionRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+    if (!session.isParticipant(user)) {
+      throw new IllegalStateException("세션 참여자만 조회할 수 있습니다.");
+    }
+
+    return SessionResponse.from(session);
+  }
+
+  public List<SessionSummaryResponse> getMySessions(Integer userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    return sessionRepository.findByMentorOrMenteeOrderByStartDateDesc(user, user).stream()
+        .map(session -> SessionSummaryResponse.of(session, user))
+        .collect(Collectors.toList());
+  }
+
+  public List<SessionSummaryResponse> getMySessionsByStatus(Integer userId, Session.SessionStatus status) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    return sessionRepository.findByMentorAndStatusOrMenteeAndStatusOrderByStartDateDesc(
+            user, status, user, status
+        ).stream()
+        .map(session -> SessionSummaryResponse.of(session, user))
+        .collect(Collectors.toList());
+  }
+
+  @Transactional
+  public SessionResponse requestEndSession(Integer sessionId, Integer userId) {
+    User requester = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    Session session = sessionRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+    session.requestEnd(requester);
+    return SessionResponse.from(session);
+  }
+
+  @Transactional
+  public SessionResponse confirmEndSession(Integer sessionId, Integer userId) {
+    User confirmer = userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+    Session session = sessionRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+
+    session.confirmEnd(confirmer);
+
+    // 세션 종료 시 채팅창 잠금
+    if (session.isCompleted()) {
+      eventPublisher.publishEvent(new SessionCompletedEvent(session));
+    }
+
+    return SessionResponse.from(session);
+  }
+}

--- a/src/main/java/com/example/mentoring/match/service/SessionService.java
+++ b/src/main/java/com/example/mentoring/match/service/SessionService.java
@@ -10,6 +10,7 @@ import com.example.mentoring.match.event.SessionCreatedEvent;
 import com.example.mentoring.match.repository.SessionRepository;
 import com.example.mentoring.member.entity.User;
 import com.example.mentoring.member.repository.UserRepository;
+import java.util.UUID;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import jakarta.persistence.EntityNotFoundException;
@@ -57,7 +58,7 @@ public class SessionService {
     return savedSession;
   }
 
-  public SessionResponse getSession(Integer sessionId, Integer userId) {
+  public SessionResponse getSession(UUID sessionId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -71,7 +72,7 @@ public class SessionService {
     return SessionResponse.from(session);
   }
 
-  public List<SessionSummaryResponse> getMySessions(Integer userId) {
+  public List<SessionSummaryResponse> getMySessions(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -80,7 +81,7 @@ public class SessionService {
         .collect(Collectors.toList());
   }
 
-  public List<SessionSummaryResponse> getMySessionsByStatus(Integer userId, Session.SessionStatus status) {
+  public List<SessionSummaryResponse> getMySessionsByStatus(UUID userId, Session.SessionStatus status) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -92,7 +93,7 @@ public class SessionService {
   }
 
   @Transactional
-  public SessionResponse requestEndSession(Integer sessionId, Integer userId) {
+  public SessionResponse requestEndSession(UUID sessionId, UUID userId) {
     User requester = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
@@ -104,7 +105,7 @@ public class SessionService {
   }
 
   @Transactional
-  public SessionResponse confirmEndSession(Integer sessionId, Integer userId) {
+  public SessionResponse confirmEndSession(UUID sessionId, UUID userId) {
     User confirmer = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 

--- a/src/main/java/com/example/mentoring/member/dto/MenteeProfileResponse.java
+++ b/src/main/java/com/example/mentoring/member/dto/MenteeProfileResponse.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.member.dto;
 
 import com.example.mentoring.member.entity.MenteeProfile;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class MenteeProfileResponse {
   // 멘티 프로필 응답 DTO
 
-  private Integer userId;
+  private UUID userId;
   private String menteeBio;
   // SystemCode의 display_name 반환
   private String fieldCode;

--- a/src/main/java/com/example/mentoring/member/dto/MentorProfileResponse.java
+++ b/src/main/java/com/example/mentoring/member/dto/MentorProfileResponse.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.member.dto;
 
 import com.example.mentoring.member.entity.MentorProfile;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,11 +14,13 @@ import lombok.NoArgsConstructor;
 public class MentorProfileResponse {
   // 멘토 프로필 응답 DTO
 
-  private Integer userId;
+  private UUID userId;
   private String mentorBio;
   private Double avgRating;
+  private Long reviewCount;
   private Integer careerYears;
   private String company;
+
   // SystemCode의 display_name 반환
   private String fieldCode;
   private String levelCode;
@@ -28,6 +31,7 @@ public class MentorProfileResponse {
         .mentorBio(profile.getMentorBio())
         // BigDecimal -> Double 변환 및 null 처리 로직
         .avgRating(profile.getAvgRating() != null ? profile.getAvgRating().doubleValue() : 0.0)
+        .reviewCount(profile.getReviewCount())
         .careerYears(profile.getCareerYears())
         .company(profile.getCompany())
         .fieldCode(profile.getFieldCode().getDisplayName())

--- a/src/main/java/com/example/mentoring/member/dto/UserResponse.java
+++ b/src/main/java/com/example/mentoring/member/dto/UserResponse.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.member.dto;
 
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import java.time.format.DateTimeFormatter;
 public class UserResponse {
   // 사용자 응답 DTO
 
-  private Integer id;
+  private UUID id;
   private String email;
   private String nickname;
   private String role;

--- a/src/main/java/com/example/mentoring/member/entity/MenteeProfile.java
+++ b/src/main/java/com/example/mentoring/member/entity/MenteeProfile.java
@@ -1,5 +1,6 @@
 package com.example.mentoring.member.entity;
 
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,7 +28,7 @@ import jakarta.persistence.Table;
 public class MenteeProfile {
 
   @Id
-  private Integer userId;
+  private UUID userId;
 
   @OneToOne
   @MapsId

--- a/src/main/java/com/example/mentoring/member/entity/MentorProfile.java
+++ b/src/main/java/com/example/mentoring/member/entity/MentorProfile.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 
 import java.math.BigDecimal;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,7 +29,7 @@ import lombok.NoArgsConstructor;
 public class MentorProfile {
 
   @Id
-  private Integer userId;
+  private UUID userId;
 
   @OneToOne
   @MapsId
@@ -41,6 +42,11 @@ public class MentorProfile {
   @Column(nullable = false, precision = 2, scale = 1)
   @Builder.Default
   private BigDecimal avgRating = BigDecimal.ZERO; // BigDecimal for 데이터 무결성
+
+  // 리뷰 개수 필드
+  @Column(nullable = false)
+  @Builder.Default
+  private Long reviewCount = 0L;
 
   @Column(nullable = false)
   private Integer careerYears;
@@ -66,7 +72,9 @@ public class MentorProfile {
     this.levelCode = levelCode;
   }
 
-  public void updateAvgRating(BigDecimal newRating) {
-    this.avgRating = newRating;
+  // 멘토 평점 및 개수 업데이트 메서드
+  public void updateRating(BigDecimal avgRating, Long reviewCount) {
+    this.avgRating = avgRating;
+    this.reviewCount = reviewCount;
   }
 }

--- a/src/main/java/com/example/mentoring/member/entity/User.java
+++ b/src/main/java/com/example/mentoring/member/entity/User.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +20,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user")
+@Table(name = "users") // DB 예약어 이슈로 변경
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -35,9 +36,11 @@ public class User {
     }
   }
 
+  // Integer id -> UUID id로 변경
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Integer id;
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(columnDefinition = "BINARY(16)")
+  private UUID id;
 
   @Column(nullable = false, unique = true, length = 225)
   private String email;

--- a/src/main/java/com/example/mentoring/member/repository/MenteeProfileRepository.java
+++ b/src/main/java/com/example/mentoring/member/repository/MenteeProfileRepository.java
@@ -1,12 +1,13 @@
 package com.example.mentoring.member.repository;
 
 import com.example.mentoring.member.entity.MenteeProfile;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface MenteeProfileRepository extends JpaRepository<MenteeProfile, Integer> {
+public interface MenteeProfileRepository extends JpaRepository<MenteeProfile, UUID> {
 
 }

--- a/src/main/java/com/example/mentoring/member/repository/MentorProfileRepository.java
+++ b/src/main/java/com/example/mentoring/member/repository/MentorProfileRepository.java
@@ -1,12 +1,14 @@
 package com.example.mentoring.member.repository;
 
 import com.example.mentoring.member.entity.MentorProfile;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
-public interface MentorProfileRepository extends JpaRepository<MentorProfile, Integer> {
-
+public interface MentorProfileRepository extends JpaRepository<MentorProfile, UUID> {
+  Optional<MentorProfile> findByUserId(UUID userId);
 }

--- a/src/main/java/com/example/mentoring/member/repository/UserRepository.java
+++ b/src/main/java/com/example/mentoring/member/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.member.repository;
 
 import com.example.mentoring.member.entity.User;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByEmail(String email);
   Optional<User> findByNickname(String nickname);
   boolean existsByEmail(String email);

--- a/src/main/java/com/example/mentoring/member/service/MemberService.java
+++ b/src/main/java/com/example/mentoring/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.example.mentoring.member.dto.UserResponse;
 import com.example.mentoring.member.entity.User;
 import com.example.mentoring.member.repository.UserRepository;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -48,7 +49,7 @@ public class MemberService {
 
   // 사용자 정보 수정
   @Transactional
-  public UserResponse updateUser(Integer userId, UpdateUserRequest request) {
+  public UserResponse updateUser(UUID userId, UpdateUserRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
 
@@ -68,7 +69,7 @@ public class MemberService {
   }
 
   // 사용자 정보 조회
-  public UserResponse getUserById(Integer userId) {
+  public UserResponse getUserById(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
     return UserResponse.from(user);
@@ -76,7 +77,7 @@ public class MemberService {
 
   // 회원 탈퇴 (Soft Delete)
   @Transactional
-  public void withdraw(Integer userId, String password) {
+  public void withdraw(UUID userId, String password) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
 

--- a/src/main/java/com/example/mentoring/member/service/MenteeService.java
+++ b/src/main/java/com/example/mentoring/member/service/MenteeService.java
@@ -9,6 +9,7 @@ import com.example.mentoring.member.entity.MenteeProfile;
 import com.example.mentoring.member.entity.User;
 import com.example.mentoring.member.repository.MenteeProfileRepository;
 import com.example.mentoring.member.repository.UserRepository;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +24,7 @@ public class MenteeService {
 
   // 멘티 프로필 생성
   @Transactional
-  public MenteeProfileResponse createMenteeProfile(Integer userId, CreateMenteeProfileRequest request) {
+  public MenteeProfileResponse createMenteeProfile(UUID userId, CreateMenteeProfileRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다"));
 
@@ -49,7 +50,7 @@ public class MenteeService {
 
   // 멘티 프로필 수정
   @Transactional
-  public MenteeProfileResponse updateMenteeProfile(Integer userId, UpdateMenteeProfileRequest request) {
+  public MenteeProfileResponse updateMenteeProfile(UUID userId, UpdateMenteeProfileRequest request) {
     MenteeProfile profile = menteeProfileRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("멘티 프로필이 존재하지 않습니다"));
 
@@ -72,7 +73,7 @@ public class MenteeService {
   }
 
   // 멘티 프로필 조회
-  public MenteeProfileResponse getMenteeProfile(Integer userId) {
+  public MenteeProfileResponse getMenteeProfile(UUID userId) {
     MenteeProfile profile = menteeProfileRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("멘티 프로필이 존재하지 않습니다"));
     return MenteeProfileResponse.from(profile);

--- a/src/main/java/com/example/mentoring/member/service/MentorService.java
+++ b/src/main/java/com/example/mentoring/member/service/MentorService.java
@@ -9,6 +9,7 @@ import com.example.mentoring.member.repository.MentorProfileRepository;
 import com.example.mentoring.member.repository.UserRepository;
 import com.example.mentoring.global.code.FieldCode;
 import com.example.mentoring.global.code.LevelCode;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +26,7 @@ public class MentorService {
 
   // 멘토 프로필 생성
   @Transactional
-  public MentorProfileResponse createMentorProfile(Integer userId, CreateMentorProfileRequest request) {
+  public MentorProfileResponse createMentorProfile(UUID userId, CreateMentorProfileRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다. ID: " + userId));
 
@@ -55,7 +56,7 @@ public class MentorService {
 
   // 멘토 프로필 수정
   @Transactional
-  public MentorProfileResponse updateMentorProfile(Integer userId, UpdateMentorProfileRequest request) {
+  public MentorProfileResponse updateMentorProfile(UUID userId, UpdateMentorProfileRequest request) {
     MentorProfile profile = mentorProfileRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("멘토 프로필이 존재하지 않습니다. ID: " + userId));
 
@@ -80,7 +81,7 @@ public class MentorService {
   }
 
   // 멘토 프로필 조회
-  public MentorProfileResponse getMentorProfile(Integer userId) {
+  public MentorProfileResponse getMentorProfile(UUID userId) {
     MentorProfile profile = mentorProfileRepository.findById(userId)
         .orElseThrow(() -> new IllegalArgumentException("멘토 프로필이 존재하지 않습니다. ID: " + userId));
     return MentorProfileResponse.from(profile);

--- a/src/test/java/com/example/mentoring/match/controller/SessionControllerTest.java
+++ b/src/test/java/com/example/mentoring/match/controller/SessionControllerTest.java
@@ -1,79 +1,79 @@
-//package com.example.mentoring.match.controller;
-//
-//import com.example.mentoring.auth.service.AuthService;
-//import com.example.mentoring.auth.service.CustomUserDetails;
-//import com.example.mentoring.auth.service.CustomUserDetailsService;
-//import com.example.mentoring.match.dto.SessionResponse;
-//import com.example.mentoring.match.entity.Session;
-//import com.example.mentoring.match.service.SessionService;
-//import com.example.mentoring.member.entity.User;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-//import org.springframework.boot.test.mock.mockito.MockBean;
-//import org.springframework.security.test.context.support.WithMockUser;
-//import org.springframework.test.web.servlet.MockMvc;
-//
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.BDDMockito.given;
-//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-//
-//@WebMvcTest(SessionController.class)
-//class SessionControllerTest {
-//
-//  @Autowired
-//  private MockMvc mockMvc;
-//
-//  @MockBean
-//  private SessionService sessionService;
-//
-//  @MockBean
-//  private AuthService authService;
-//
-//  @MockBean
-//  private com.example.mentoring.global.util.JwtUtil jwtUtil;
-//
-//  @MockBean
-//  private CustomUserDetailsService customUserDetailsService;
-//
-//  @Test
-//  @DisplayName("멘토링 종료 확인 요청 API 테스트")
-//  @WithMockUser
-//  void confirmEndSession() throws Exception {
-//    // given
-//    Integer sessionId = 1;
-//    Integer userId = 100;
-//
-//    User mockUser = User.builder()
-//        .id(userId)
-//        .email("test@test.com")
-//        .password("password")
-//        .role(User.Role.MENTOR)
-//        .isActive(true)
-//        .build();
-//
-//    CustomUserDetails userDetails = new CustomUserDetails(mockUser);
-//    given(authService.getCurrentUser()).willReturn(userDetails);
-//
-//    // Service가 반환할 응답 Mocking
-//    SessionResponse mockResponse = SessionResponse.builder()
-//        .id(sessionId)
-//        .status(Session.SessionStatus.COMPLETED)
-//        .build();
-//
-//    given(sessionService.confirmEndSession(eq(sessionId), eq(userId)))
-//        .willReturn(mockResponse);
-//
-//    // when & then
-//    mockMvc.perform(patch("/api/sessions/{sessionId}/confirm-end", sessionId)
-//            .with(csrf())) // POST, PATCH, DELETE 등은 CSRF 토큰 필요
-//        .andDo(print())
-//        .andExpect(status().isOk())
-//        .andExpect(jsonPath("$.status").value("COMPLETED"));
-//  }
-//}
+package com.example.mentoring.match.controller;
+
+import com.example.mentoring.auth.service.AuthService;
+import com.example.mentoring.auth.service.CustomUserDetails;
+import com.example.mentoring.auth.service.CustomUserDetailsService;
+import com.example.mentoring.match.dto.SessionResponse;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.service.SessionService;
+import com.example.mentoring.member.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SessionController.class)
+class SessionControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private SessionService sessionService;
+
+  @MockBean
+  private AuthService authService;
+
+  @MockBean
+  private com.example.mentoring.global.util.JwtUtil jwtUtil;
+
+  @MockBean
+  private CustomUserDetailsService customUserDetailsService;
+
+  @Test
+  @DisplayName("멘토링 종료 확인 요청 API 테스트")
+  @WithMockUser
+  void confirmEndSession() throws Exception {
+    // given
+    Integer sessionId = 1;
+    Integer userId = 100;
+
+    User mockUser = User.builder()
+        .id(userId)
+        .email("test@test.com")
+        .password("password")
+        .role(User.Role.MENTOR)
+        .isActive(true)
+        .build();
+
+    CustomUserDetails userDetails = new CustomUserDetails(mockUser);
+    given(authService.getCurrentUser()).willReturn(userDetails);
+
+    // Service가 반환할 응답 Mocking
+    SessionResponse mockResponse = SessionResponse.builder()
+        .id(sessionId)
+        .status(Session.SessionStatus.COMPLETED)
+        .build();
+
+    given(sessionService.confirmEndSession(eq(sessionId), eq(userId)))
+        .willReturn(mockResponse);
+
+    // when & then
+    mockMvc.perform(patch("/api/sessions/{sessionId}/confirm-end", sessionId)
+            .with(csrf())) // POST, PATCH, DELETE 등은 CSRF 토큰 필요
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.status").value("COMPLETED"));
+  }
+}

--- a/src/test/java/com/example/mentoring/match/controller/SessionControllerTest.java
+++ b/src/test/java/com/example/mentoring/match/controller/SessionControllerTest.java
@@ -1,0 +1,79 @@
+//package com.example.mentoring.match.controller;
+//
+//import com.example.mentoring.auth.service.AuthService;
+//import com.example.mentoring.auth.service.CustomUserDetails;
+//import com.example.mentoring.auth.service.CustomUserDetailsService;
+//import com.example.mentoring.match.dto.SessionResponse;
+//import com.example.mentoring.match.entity.Session;
+//import com.example.mentoring.match.service.SessionService;
+//import com.example.mentoring.member.entity.User;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.security.test.context.support.WithMockUser;
+//import org.springframework.test.web.servlet.MockMvc;
+//
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.BDDMockito.given;
+//import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@WebMvcTest(SessionController.class)
+//class SessionControllerTest {
+//
+//  @Autowired
+//  private MockMvc mockMvc;
+//
+//  @MockBean
+//  private SessionService sessionService;
+//
+//  @MockBean
+//  private AuthService authService;
+//
+//  @MockBean
+//  private com.example.mentoring.global.util.JwtUtil jwtUtil;
+//
+//  @MockBean
+//  private CustomUserDetailsService customUserDetailsService;
+//
+//  @Test
+//  @DisplayName("멘토링 종료 확인 요청 API 테스트")
+//  @WithMockUser
+//  void confirmEndSession() throws Exception {
+//    // given
+//    Integer sessionId = 1;
+//    Integer userId = 100;
+//
+//    User mockUser = User.builder()
+//        .id(userId)
+//        .email("test@test.com")
+//        .password("password")
+//        .role(User.Role.MENTOR)
+//        .isActive(true)
+//        .build();
+//
+//    CustomUserDetails userDetails = new CustomUserDetails(mockUser);
+//    given(authService.getCurrentUser()).willReturn(userDetails);
+//
+//    // Service가 반환할 응답 Mocking
+//    SessionResponse mockResponse = SessionResponse.builder()
+//        .id(sessionId)
+//        .status(Session.SessionStatus.COMPLETED)
+//        .build();
+//
+//    given(sessionService.confirmEndSession(eq(sessionId), eq(userId)))
+//        .willReturn(mockResponse);
+//
+//    // when & then
+//    mockMvc.perform(patch("/api/sessions/{sessionId}/confirm-end", sessionId)
+//            .with(csrf())) // POST, PATCH, DELETE 등은 CSRF 토큰 필요
+//        .andDo(print())
+//        .andExpect(status().isOk())
+//        .andExpect(jsonPath("$.status").value("COMPLETED"));
+//  }
+//}

--- a/src/test/java/com/example/mentoring/match/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/mentoring/match/service/ApplicationServiceTest.java
@@ -1,0 +1,71 @@
+package com.example.mentoring.match.service;
+
+import com.example.mentoring.match.dto.ApplicationResponse;
+import com.example.mentoring.match.entity.Application;
+import com.example.mentoring.match.entity.Post;
+import com.example.mentoring.match.event.ApplicationApprovedEvent;
+import com.example.mentoring.match.repository.ApplicationRepository;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationServiceTest {
+
+  @InjectMocks
+  private ApplicationService applicationService;
+
+  @Mock
+  private ApplicationRepository applicationRepository;
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private ApplicationEventPublisher eventPublisher; // 이벤트 발행기 Mock
+
+  @Test
+  @DisplayName("멘토링 신청 승인 성공 및 이벤트 발행 테스트")
+  void approveApplication_Success() {
+    // given
+    Integer applicationId = 1;
+    Integer mentorId = 10;
+    Integer menteeId = 20;
+
+    User mentor = User.builder().id(mentorId).nickname("Mentor").build();
+    User mentee = User.builder().id(menteeId).nickname("Mentee").build();
+    Post post = Post.builder().id(100).user(mentor).build(); // 게시글 작성자 = 멘토
+
+    Application application = Application.builder()
+        .id(applicationId)
+        .post(post)
+        .user(mentee)
+        .status(Application.ApplicationStatus.PENDING) // 초기 상태 대기
+        .build();
+
+    given(userRepository.findById(mentorId)).willReturn(Optional.of(mentor));
+    given(applicationRepository.findById(applicationId)).willReturn(Optional.of(application));
+
+    // when
+    ApplicationResponse response = applicationService.approveApplication(applicationId, mentorId);
+
+    // then
+    // 1. 상태 변경 확인
+    assertThat(response.getStatus()).isEqualTo(Application.ApplicationStatus.APPROVED);
+
+    // 2. 이벤트 발행 확인 (이벤트를 1번 발행했는지)
+    verify(eventPublisher, times(1)).publishEvent(any(ApplicationApprovedEvent.class));
+  }
+}

--- a/src/test/java/com/example/mentoring/match/service/SessionServiceTest.java
+++ b/src/test/java/com/example/mentoring/match/service/SessionServiceTest.java
@@ -1,0 +1,77 @@
+package com.example.mentoring.match.service;
+
+import com.example.mentoring.match.dto.SessionResponse;
+import com.example.mentoring.match.entity.Application;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.event.SessionCompletedEvent;
+import com.example.mentoring.match.repository.SessionRepository;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+  @InjectMocks
+  private SessionService sessionService;
+
+  @Mock
+  private SessionRepository sessionRepository;
+  @Mock
+  private UserRepository userRepository;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+
+  @Test
+  @DisplayName("멘토링 종료 최종 확인 및 완료 이벤트 발행 테스트")
+  void confirmEndSession_Complete() {
+    // given
+    Integer sessionId = 1;
+    Integer menteeId = 20;
+
+    User mentor = User.builder().id(10).nickname("Mentor").build();
+    User mentee = User.builder().id(menteeId).nickname("Mentee").build();
+
+    Application application = Application.builder().id(50).build();
+
+    // 이미 종료 요청 상태이고 멘토는 이미 확인을 누른 상태
+    Session session = Session.builder()
+        .id(sessionId)
+        .mentor(mentor)
+        .mentee(mentee)
+        .status(Session.SessionStatus.END_REQUESTED)
+        .mentorConfirm(true)  // 멘토는 이미 확인 함
+        .menteeConfirm(false) // 멘티가 아직 안 함
+        .application(application)
+        .build();
+
+    given(userRepository.findById(menteeId)).willReturn(Optional.of(mentee));
+    given(sessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+
+    // when
+    // 멘티가 종료 확인 요청
+    SessionResponse response = sessionService.confirmEndSession(sessionId, menteeId);
+
+    // then
+    // 상태가 COMPLETED로 변경되었는지 확인
+    assertThat(response.getStatus()).isEqualTo(Session.SessionStatus.COMPLETED);
+    assertThat(response.getMenteeConfirm()).isTrue();
+
+    // 세션 종료 이벤트 발행 확인
+    verify(eventPublisher, times(1)).publishEvent(any(SessionCompletedEvent.class));
+  }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 멘토링 매칭 상태(Application 승인) 이후의 관리 로직이 부재했습니다.
- ApplicationService가 SessionService를 직접 호출하는 강한 결합으로 이루어져 있었습니다.
- 실시간 채팅 연결 및 인증 방식이 부재했습니다.

**TO-BE**
- Application 승인이 끝나면 자동으로 멘토링 세션과 채팅방이 생성됩니다.
<img width="563" height="869" alt="스크린샷 2025-12-06 153746" src="https://github.com/user-attachments/assets/48cfddf5-4d58-4389-8519-6448d08d5e5c" />
<img width="1277" height="674" alt="스크린샷 2025-12-06 154011" src="https://github.com/user-attachments/assets/bec61920-22cb-4059-b10f-fb1ab7a1d7d7" />

- 매칭 세션 상태 관리 로직: SessionStatus Enum(PROGRESS, END_REQUESTED, COMPLETED) 기반의 3단계 상태 전이 로직을 구현했습니다.
<img width="692" height="880" alt="스크린샷 2025-12-06 162627" src="https://github.com/user-attachments/assets/0d8bf235-f8e8-4145-80a4-28628c6b1943" />
<img width="727" height="873" alt="스크린샷 2025-12-06 162902" src="https://github.com/user-attachments/assets/a4d1700d-8703-4bc6-95de-7ce8bb32511d" />

- 이벤트 기반 서비스 의존성 해소 : ApplicationService는 SessionService를 직접 호출하지 않고, ApplicationApprovedEvent를 발행하도록 수정했습니다. SessionService는 세션 생성 후 SessionCreatedEvent를 발행합니다.
- 구독 로직: SessionService는 ApplicationApprovedEvent를 구독하여 세션 생성(createSession)을 담당합니다.
ChatService는 SessionCreatedEvent를 구독하여 채팅방 생성(createChatRoom)을 담당합니다.
ChatService는 SessionCompletedEvent를 구독하여 채팅방 잠금(lockChatRoom)을 담당합니다.
- WebSocket Handler 구현: ChatWebSocketHandler를 정의하여 메시지 수신, 연결/종료 및 유저 인증 로직을 구현했습니다.
<img width="686" height="486" alt="스크린샷 2025-12-06 154619" src="https://github.com/user-attachments/assets/8a3536fc-5299-464b-b30b-80464ef1385d" />

- Redis Pub/Sub 연동: RedisPublisher와 RedisSubscriber를 도입하여 메시지 브로드캐스팅을 Redis 기반으로 처리했습니다.
<img width="1330" height="735" alt="스크린샷 2025-12-06 155649" src="https://github.com/user-attachments/assets/c94da623-4e64-4941-a2c6-910f9c57fc0d" />
<img width="761" height="422" alt="스크린샷 2025-12-06 161223" src="https://github.com/user-attachments/assets/37bd7bbf-449e-466b-a021-cfa1a2059499" />

- 인증 연동: ChatHandshakeInterceptor를 구현하여 HTTP 핸드셰이크 과정에서 JWT 필터를 통해 확인된 Principal 정보를 WebSocket Session 속성으로 전달합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 : ApplicationServiceTest, SessionServiceTest를 통해 비즈니스 로직 및 Spring Event 발행/수신을 verify()를 이용해 검증 완료. SessionController의 API 호출 및 인증/인가(AuthService Mocking) 검증 완료
- [x] API 테스트 : Postman WebSocket 클라이언트로 웹소켓 채팅 구현 테스트 완료