### PR TITLE
feat: 리뷰 기능 구현, Post 미구현 파트 보완

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,10 +40,16 @@ dependencies {
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation("com.h2database:h2") // 테스트용 DB
 	// JWT 간소화
 	implementation ("io.jsonwebtoken:jjwt:0.12.5")
 	// Java 8 Date/Time (LocalDateTime) 직렬화
 	implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+	// QueryDSL
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/example/mentoring/MentoringApplication.java
+++ b/src/main/java/com/example/mentoring/MentoringApplication.java
@@ -2,7 +2,9 @@ package com.example.mentoring;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MentoringApplication {
 

--- a/src/main/java/com/example/mentoring/global/config/QueryDslConfig.java
+++ b/src/main/java/com/example/mentoring/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.example.mentoring.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/example/mentoring/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/mentoring/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.example.mentoring.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+  // 공통 시간 관리 엔티티
+
+  @CreatedDate
+  @Column(updatable = false) // 생성 시간은 수정되지 않도록 설정
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  private LocalDateTime updatedAt; // 수정될 때마다 자동 업데이트
+}

--- a/src/main/java/com/example/mentoring/match/controller/PostController.java
+++ b/src/main/java/com/example/mentoring/match/controller/PostController.java
@@ -8,8 +8,8 @@ import com.example.mentoring.match.dto.PostSearchCondition;
 import com.example.mentoring.match.dto.PostSummaryResponse;
 import com.example.mentoring.match.dto.UpdatePostRequest;
 import com.example.mentoring.match.service.PostService;
-import com.example.mentoring.member.entity.User;
 import jakarta.validation.Valid; // 필수 Import
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -93,7 +93,7 @@ public class PostController {
 
   // 특정 유저(멘토)가 작성한 게시글 목록 조회
   @GetMapping("/list/{userId}")
-  public ResponseEntity<List<PostSummaryResponse>> getPostsByUserId(@PathVariable Integer userId) {
+  public ResponseEntity<List<PostSummaryResponse>> getPostsByUserId(@PathVariable UUID userId) {
 
     List<PostSummaryResponse> responses = postService.getPostsByUserId(userId);
 

--- a/src/main/java/com/example/mentoring/match/controller/PostController.java
+++ b/src/main/java/com/example/mentoring/match/controller/PostController.java
@@ -4,6 +4,7 @@ import com.example.mentoring.auth.service.AuthService;
 import com.example.mentoring.auth.service.CustomUserDetails;
 import com.example.mentoring.match.dto.CreatePostRequest;
 import com.example.mentoring.match.dto.PostResponse;
+import com.example.mentoring.match.dto.PostSearchCondition;
 import com.example.mentoring.match.dto.PostSummaryResponse;
 import com.example.mentoring.match.dto.UpdatePostRequest;
 import com.example.mentoring.match.service.PostService;
@@ -74,6 +75,20 @@ public class PostController {
       @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
     Page<PostResponse> responses = postService.getAllPosts(pageable);
     return ResponseEntity.ok(responses);
+  }
+
+  @GetMapping("/search")
+  public ResponseEntity<Page<PostResponse>> searchPosts(
+      @RequestParam(required = false) String keyword,
+      @RequestParam(required = false) List<Integer> tagIds,
+      @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+
+    PostSearchCondition condition = new PostSearchCondition();
+    condition.setKeyword(keyword);
+    condition.setTagIds(tagIds);
+
+    Page<PostResponse> result = postService.searchPosts(condition, pageable);
+    return ResponseEntity.ok(result);
   }
 
   // 특정 유저(멘토)가 작성한 게시글 목록 조회

--- a/src/main/java/com/example/mentoring/match/dto/PostResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/PostResponse.java
@@ -4,6 +4,7 @@ package com.example.mentoring.match.dto;
 import com.example.mentoring.match.entity.Post;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +20,7 @@ public class PostResponse {
   // 게시글 응답 (상세) DTO
 
     private Integer id;
-    private Integer userId;
+    private UUID userId;
     private String nickname; // 작성자 닉네임
 
     private String fieldCode;

--- a/src/main/java/com/example/mentoring/match/dto/PostSearchCondition.java
+++ b/src/main/java/com/example/mentoring/match/dto/PostSearchCondition.java
@@ -1,0 +1,10 @@
+package com.example.mentoring.match.dto;
+
+import lombok.Data;
+import java.util.List;
+
+@Data
+public class PostSearchCondition {
+  private String keyword;       // 제목 + 내용 검색어
+  private List<Integer> tagIds; // 필터링할 태그 ID 목록
+}

--- a/src/main/java/com/example/mentoring/match/dto/PostSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/match/dto/PostSummaryResponse.java
@@ -2,6 +2,7 @@ package com.example.mentoring.match.dto;
 
 import com.example.mentoring.match.entity.Post;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/example/mentoring/match/entity/Post.java
+++ b/src/main/java/com/example/mentoring/match/entity/Post.java
@@ -2,6 +2,7 @@ package com.example.mentoring.match.entity;
 
 import com.example.mentoring.global.code.FieldCode;
 import com.example.mentoring.global.code.LevelCode;
+import com.example.mentoring.global.entity.BaseEntity;
 import com.example.mentoring.member.entity.User;
 
 import jakarta.persistence.CascadeType;
@@ -35,7 +36,7 @@ import java.util.ArrayList;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Post {
+public class Post extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/mentoring/match/repository/PostRepository.java
+++ b/src/main/java/com/example/mentoring/match/repository/PostRepository.java
@@ -6,15 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Integer> {
+public interface PostRepository extends JpaRepository<Post, Integer>, PostRepositoryCustom {
 
   // 마이페이지: 내가 쓴 글 조회
   List<Post> findByUserOrderByCreatedAtDesc(User user);

--- a/src/main/java/com/example/mentoring/match/repository/PostRepositoryCustom.java
+++ b/src/main/java/com/example/mentoring/match/repository/PostRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.example.mentoring.match.repository;
+
+import com.example.mentoring.match.dto.PostResponse;
+import com.example.mentoring.match.dto.PostSearchCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostRepositoryCustom {
+  Page<PostResponse> search(PostSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/com/example/mentoring/match/repository/PostRepositoryImpl.java
+++ b/src/main/java/com/example/mentoring/match/repository/PostRepositoryImpl.java
@@ -1,0 +1,88 @@
+package com.example.mentoring.match.repository;
+
+import com.example.mentoring.match.dto.PostResponse;
+import com.example.mentoring.match.dto.PostSearchCondition;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.mentoring.match.entity.QPost.post;
+import static com.example.mentoring.match.entity.QPostTag.postTag;
+import static com.example.mentoring.match.entity.QTag.tag;
+import static com.example.mentoring.member.entity.QUser.user;
+
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<PostResponse> search(PostSearchCondition condition, Pageable pageable) {
+
+    // 컨텐츠 조회 쿼리
+    List<com.example.mentoring.match.entity.Post> posts = queryFactory
+        .selectFrom(post)
+        .leftJoin(post.user, user).fetchJoin() // N+1 문제 방지
+        .where(
+            isRecruiting(),
+            keywordContains(condition.getKeyword()),
+            tagIn(condition.getTagIds())
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .orderBy(post.createdAt.desc()) // 최신순 정렬
+        .distinct() // 태그 조인 시 중복 제거
+        .fetch();
+
+    JPAQuery<Long> countQuery = queryFactory
+        .select(post.count())
+        .from(post)
+        .where(
+            isRecruiting(),
+            keywordContains(condition.getKeyword()),
+            tagIn(condition.getTagIds())
+        );
+
+    List<PostResponse> content = posts.stream()
+        .map(PostResponse::from)
+        .collect(Collectors.toList());
+
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+  }
+
+  // 동적 쿼리 조건 메서드들
+
+  private BooleanExpression isRecruiting() {
+    return post.isRecruiting.isTrue();
+  }
+
+  private BooleanExpression keywordContains(String keyword) {
+    if (!StringUtils.hasText(keyword)) {
+      return null;
+    }
+    // 제목이나 내용에 키워드가 포함되어 있으면 True
+    return post.title.contains(keyword).or(post.content.contains(keyword));
+  }
+
+  private BooleanExpression tagIn(List<Integer> tagIds) {
+    if (tagIds == null || tagIds.isEmpty()) {
+      return null;
+    }
+    // Post -> PostTag 연결이 필요하므로 서브쿼리나 Join을 사용할 수 있음.
+    // 여기서는 간단하게 where 절 내에서 any() 사용 예시:
+    // return post.postTags.any().tag.id.in(tagIds);
+
+    // 혹은 명시적 Join을 원한다면 메인 쿼리에 join을 걸어야 함.
+    // 위 search 메서드에 .leftJoin(post.postTags, postTag) 추가 필요.
+    return post.postTags.any().tag.id.in(tagIds);
+  }
+}

--- a/src/main/java/com/example/mentoring/match/service/PostService.java
+++ b/src/main/java/com/example/mentoring/match/service/PostService.java
@@ -6,6 +6,8 @@ import com.example.mentoring.match.dto.CreatePostRequest;
 import com.example.mentoring.match.dto.PostResponse;
 import com.example.mentoring.match.dto.PostSummaryResponse;
 import com.example.mentoring.member.repository.UserRepository;
+import com.example.mentoring.member.entity.MentorProfile;
+import com.example.mentoring.member.repository.MentorProfileRepository;
 import com.example.mentoring.match.dto.UpdatePostRequest;
 import com.example.mentoring.match.entity.Post;
 import com.example.mentoring.match.entity.PostTag;
@@ -14,11 +16,14 @@ import com.example.mentoring.match.repository.PostRepository;
 import com.example.mentoring.match.repository.TagRepository;
 import com.example.mentoring.member.entity.User;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.example.mentoring.match.dto.PostSearchCondition;
+import org.springframework.data.jpa.domain.Specification;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,9 +36,10 @@ public class PostService {
   private final PostRepository postRepository;
   private final TagRepository tagRepository;
   private final UserRepository userRepository;
+  private final MentorProfileRepository mentorProfileRepository;
 
   @Transactional
-  public PostResponse createPost(Integer userId, CreatePostRequest request) {
+  public PostResponse createPost(UUID userId, CreatePostRequest request) {
     // userId를 사용하여 User 객체 조회
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("작성자(User)를 찾을 수 없습니다."));
@@ -42,8 +48,18 @@ public class PostService {
       throw new IllegalStateException("멘토만 모집글을 작성할 수 있습니다.");
     }
 
+    // 멘토 프로필 조회 및 레벨 검증 로직
+    MentorProfile mentorProfile = mentorProfileRepository.findByUserId(userId)
+        .orElseThrow(() -> new EntityNotFoundException("멘토 프로필을 찾을 수 없습니다."));
+
+    LevelCode requestLevel = LevelCode.fromValue(request.getLevelCode());
+
+    // 요청한 레벨이 멘토의 레벨보다 높으면 예외 발생 (Enum의 순서 비교)
+    if (requestLevel.compareTo(mentorProfile.getLevelCode()) > 0) {
+      throw new IllegalArgumentException("본인의 멘토 레벨보다 높은 레벨의 모집글은 작성할 수 없습니다.");
+    }
+
     FieldCode fieldCode = FieldCode.fromValue(request.getFieldCode());
-    LevelCode levelCode = LevelCode.fromValue(request.getLevelCode());
 
     // Post 객체 생성
     Post post = Post.builder()
@@ -51,7 +67,7 @@ public class PostService {
         .title(request.getTitle())
         .content(request.getContent())
         .fieldCode(fieldCode)
-        .levelCode(levelCode)
+        .levelCode(requestLevel)
         .isRecruiting(true)
         .build();
 
@@ -74,7 +90,7 @@ public class PostService {
 
   // 게시글 수정
   @Transactional
-  public PostResponse updatePost(Integer postId, Integer userId, UpdatePostRequest request) {
+  public PostResponse updatePost(Integer postId, UUID userId, UpdatePostRequest request) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -85,10 +101,18 @@ public class PostService {
       throw new IllegalStateException("본인이 작성한 게시글만 수정할 수 있습니다.");
     }
 
-    FieldCode fieldCode = FieldCode.fromValue(request.getFieldCode());
-    LevelCode levelCode = LevelCode.fromValue(request.getLevelCode());
+    MentorProfile mentorProfile = mentorProfileRepository.findByUserId(userId)
+        .orElseThrow(() -> new EntityNotFoundException("멘토 프로필을 찾을 수 없습니다."));
 
-    post.updatePost(request.getTitle(), request.getContent(), fieldCode, levelCode);
+    LevelCode requestLevel = LevelCode.fromValue(request.getLevelCode());
+
+    if (requestLevel.compareTo(mentorProfile.getLevelCode()) > 0) {
+      throw new IllegalArgumentException("본인의 멘토 레벨보다 높은 레벨로 수정할 수 없습니다.");
+    }
+
+    FieldCode fieldCode = FieldCode.fromValue(request.getFieldCode());
+
+    post.updatePost(request.getTitle(), request.getContent(), fieldCode, requestLevel);
 
     // 태그 업데이트 (기존 태그 삭제 후 재생성)
     post.clearPostTags();
@@ -108,7 +132,7 @@ public class PostService {
 
   // 게시글 삭제
   @Transactional
-  public void deletePost(Integer postId, Integer userId) {
+  public void deletePost(Integer postId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -128,14 +152,20 @@ public class PostService {
     return PostResponse.from(post);
   }
 
+
   // 페이징 적용: 메인 페이지 조회
   public Page<PostResponse> getAllPosts(Pageable pageable) {
     return postRepository.findByIsRecruitingTrueOrderByCreatedAtDesc(pageable)
         .map(PostResponse::from);
   }
 
+  // 검색 및 필터링
+  public Page<PostResponse> searchPosts(PostSearchCondition condition, Pageable pageable) {
+    return postRepository.search(condition, pageable);
+  }
+
   // 유저 글 목록 조회
-  public List<PostSummaryResponse> getPostsByUserId(Integer userId) {
+  public List<PostSummaryResponse> getPostsByUserId(UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -146,7 +176,7 @@ public class PostService {
 
   // 모집 마감
   @Transactional
-  public void closeRecruitment(Integer postId, Integer userId) {
+  public void closeRecruitment(Integer postId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 
@@ -161,7 +191,7 @@ public class PostService {
 
   // 모집 재개
   @Transactional
-  public void openRecruitment(Integer postId, Integer userId) {
+  public void openRecruitment(Integer postId, UUID userId) {
     User user = userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자(User)를 찾을 수 없습니다."));
 

--- a/src/main/java/com/example/mentoring/review/controller/ReviewController.java
+++ b/src/main/java/com/example/mentoring/review/controller/ReviewController.java
@@ -6,7 +6,8 @@ import com.example.mentoring.review.dto.ReviewSummaryResponse;
 import com.example.mentoring.review.dto.UpdateReviewRequest;
 import com.example.mentoring.review.dto.UserRatingResponse;
 import com.example.mentoring.review.service.ReviewService;
-import jakarta.validation.Valid; // [필수] 유효성 검사를 위해 추가
+import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -31,8 +32,8 @@ public class ReviewController {
   // 리뷰 작성
   @PostMapping("/session/{sessionId}")
   public ResponseEntity<ReviewResponse> createReview(
-      @PathVariable Integer sessionId,
-      @AuthenticationPrincipal Integer userId,
+      @PathVariable UUID sessionId,
+      @AuthenticationPrincipal UUID userId,
       @Valid @RequestBody CreateReviewRequest request) {
     ReviewResponse response = reviewService.createReview(sessionId, userId, request);
     return ResponseEntity.ok(response);
@@ -42,7 +43,7 @@ public class ReviewController {
   @PutMapping("/{reviewId}")
   public ResponseEntity<ReviewResponse> updateReview(
       @PathVariable Integer reviewId,
-      @AuthenticationPrincipal Integer userId,
+      @AuthenticationPrincipal UUID userId,
       @Valid @RequestBody UpdateReviewRequest request) {
     ReviewResponse response = reviewService.updateReview(reviewId, userId, request);
     return ResponseEntity.ok(response);
@@ -52,7 +53,7 @@ public class ReviewController {
   @DeleteMapping("/{reviewId}")
   public ResponseEntity<Void> deleteReview(
       @PathVariable Integer reviewId,
-      @AuthenticationPrincipal Integer userId) {
+      @AuthenticationPrincipal UUID userId) {
     reviewService.deleteReview(reviewId, userId);
     return ResponseEntity.noContent().build();
   }
@@ -66,7 +67,7 @@ public class ReviewController {
 
   // 세션의 모든 리뷰 조회
   @GetMapping("/session/{sessionId}")
-  public ResponseEntity<List<ReviewResponse>> getReviewsBySession(@PathVariable Integer sessionId) {
+  public ResponseEntity<List<ReviewResponse>> getReviewsBySession(@PathVariable UUID sessionId) {
     List<ReviewResponse> responses = reviewService.getReviewsBySession(sessionId);
     return ResponseEntity.ok(responses);
   }
@@ -74,7 +75,7 @@ public class ReviewController {
   // 받은 리뷰 목록 조회
   @GetMapping("/user/{userId}/received")
   public ResponseEntity<List<ReviewSummaryResponse>> getReceivedReviews(
-      @PathVariable Integer userId) {
+      @PathVariable UUID userId) {
     List<ReviewSummaryResponse> responses = reviewService.getReceivedReviews(userId);
     return ResponseEntity.ok(responses);
   }
@@ -82,7 +83,7 @@ public class ReviewController {
   // 작성한 리뷰 목록 조회
   @GetMapping("/user/{userId}/written")
   public ResponseEntity<List<ReviewSummaryResponse>> getWrittenReviews(
-      @PathVariable Integer userId) {
+      @PathVariable UUID userId) {
     List<ReviewSummaryResponse> responses = reviewService.getWrittenReviews(userId);
     return ResponseEntity.ok(responses);
   }
@@ -90,7 +91,7 @@ public class ReviewController {
   // 내가 받은 리뷰 목록 조회 (편의 기능)
   @GetMapping("/my/received")
   public ResponseEntity<List<ReviewSummaryResponse>> getMyReceivedReviews(
-      @AuthenticationPrincipal Integer userId) {
+      @AuthenticationPrincipal UUID userId) {
     List<ReviewSummaryResponse> responses = reviewService.getReceivedReviews(userId);
     return ResponseEntity.ok(responses);
   }
@@ -98,14 +99,14 @@ public class ReviewController {
   // 내가 작성한 리뷰 목록 조회 (편의 기능)
   @GetMapping("/my/written")
   public ResponseEntity<List<ReviewSummaryResponse>> getMyWrittenReviews(
-      @AuthenticationPrincipal Integer userId) {
+      @AuthenticationPrincipal UUID userId) {
     List<ReviewSummaryResponse> responses = reviewService.getWrittenReviews(userId);
     return ResponseEntity.ok(responses);
   }
 
   // 사용자 평점 통계 조회
   @GetMapping("/user/{userId}/rating")
-  public ResponseEntity<UserRatingResponse> getUserRating(@PathVariable Integer userId) {
+  public ResponseEntity<UserRatingResponse> getUserRating(@PathVariable UUID userId) {
     UserRatingResponse response = reviewService.getUserRating(userId);
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/example/mentoring/review/controller/ReviewController.java
+++ b/src/main/java/com/example/mentoring/review/controller/ReviewController.java
@@ -1,0 +1,112 @@
+package com.example.mentoring.review.controller;
+
+import com.example.mentoring.review.dto.CreateReviewRequest;
+import com.example.mentoring.review.dto.ReviewResponse;
+import com.example.mentoring.review.dto.ReviewSummaryResponse;
+import com.example.mentoring.review.dto.UpdateReviewRequest;
+import com.example.mentoring.review.dto.UserRatingResponse;
+import com.example.mentoring.review.service.ReviewService;
+import jakarta.validation.Valid; // [필수] 유효성 검사를 위해 추가
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/review")
+@RequiredArgsConstructor
+public class ReviewController {
+
+  private final ReviewService reviewService;
+
+  // 리뷰 작성
+  @PostMapping("/session/{sessionId}")
+  public ResponseEntity<ReviewResponse> createReview(
+      @PathVariable Integer sessionId,
+      @AuthenticationPrincipal Integer userId,
+      @Valid @RequestBody CreateReviewRequest request) {
+    ReviewResponse response = reviewService.createReview(sessionId, userId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  // 리뷰 수정
+  @PutMapping("/{reviewId}")
+  public ResponseEntity<ReviewResponse> updateReview(
+      @PathVariable Integer reviewId,
+      @AuthenticationPrincipal Integer userId,
+      @Valid @RequestBody UpdateReviewRequest request) {
+    ReviewResponse response = reviewService.updateReview(reviewId, userId, request);
+    return ResponseEntity.ok(response);
+  }
+
+  // 리뷰 삭제
+  @DeleteMapping("/{reviewId}")
+  public ResponseEntity<Void> deleteReview(
+      @PathVariable Integer reviewId,
+      @AuthenticationPrincipal Integer userId) {
+    reviewService.deleteReview(reviewId, userId);
+    return ResponseEntity.noContent().build();
+  }
+
+  // 리뷰 상세 조회
+  @GetMapping("/{reviewId}")
+  public ResponseEntity<ReviewResponse> getReview(@PathVariable Integer reviewId) {
+    ReviewResponse response = reviewService.getReview(reviewId);
+    return ResponseEntity.ok(response);
+  }
+
+  // 세션의 모든 리뷰 조회
+  @GetMapping("/session/{sessionId}")
+  public ResponseEntity<List<ReviewResponse>> getReviewsBySession(@PathVariable Integer sessionId) {
+    List<ReviewResponse> responses = reviewService.getReviewsBySession(sessionId);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 받은 리뷰 목록 조회
+  @GetMapping("/user/{userId}/received")
+  public ResponseEntity<List<ReviewSummaryResponse>> getReceivedReviews(
+      @PathVariable Integer userId) {
+    List<ReviewSummaryResponse> responses = reviewService.getReceivedReviews(userId);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 작성한 리뷰 목록 조회
+  @GetMapping("/user/{userId}/written")
+  public ResponseEntity<List<ReviewSummaryResponse>> getWrittenReviews(
+      @PathVariable Integer userId) {
+    List<ReviewSummaryResponse> responses = reviewService.getWrittenReviews(userId);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 내가 받은 리뷰 목록 조회 (편의 기능)
+  @GetMapping("/my/received")
+  public ResponseEntity<List<ReviewSummaryResponse>> getMyReceivedReviews(
+      @AuthenticationPrincipal Integer userId) {
+    List<ReviewSummaryResponse> responses = reviewService.getReceivedReviews(userId);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 내가 작성한 리뷰 목록 조회 (편의 기능)
+  @GetMapping("/my/written")
+  public ResponseEntity<List<ReviewSummaryResponse>> getMyWrittenReviews(
+      @AuthenticationPrincipal Integer userId) {
+    List<ReviewSummaryResponse> responses = reviewService.getWrittenReviews(userId);
+    return ResponseEntity.ok(responses);
+  }
+
+  // 사용자 평점 통계 조회
+  @GetMapping("/user/{userId}/rating")
+  public ResponseEntity<UserRatingResponse> getUserRating(@PathVariable Integer userId) {
+    UserRatingResponse response = reviewService.getUserRating(userId);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/src/main/java/com/example/mentoring/review/dto/CreateReviewRequest.java
+++ b/src/main/java/com/example/mentoring/review/dto/CreateReviewRequest.java
@@ -1,0 +1,24 @@
+package com.example.mentoring.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateReviewRequest {
+  // 리뷰 생성 요청 DTO
+
+  @NotNull(message = "평점은 필수 입력 값입니다.")
+  @Min(value = 1, message = "평점은 최소 1점이어야 합니다.")
+  @Max(value = 5, message = "평점은 최대 5점이어야 합니다.")
+  private Integer rating;
+
+  @NotBlank(message = "리뷰 내용은 필수 입력 값입니다.")
+  private String content;
+}

--- a/src/main/java/com/example/mentoring/review/dto/ReviewResponse.java
+++ b/src/main/java/com/example/mentoring/review/dto/ReviewResponse.java
@@ -1,0 +1,41 @@
+package com.example.mentoring.review.dto;
+
+import com.example.mentoring.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewResponse {
+  // 리뷰 응답 DTO
+
+  private Integer id;
+  private Integer sessionId;
+  private Integer reviewerId;
+  private String reviewerNickname;
+  private Integer targetId;
+  private String targetNickname;
+  private Integer rating;
+  private String content;
+  private LocalDateTime createdAt;
+
+  public static ReviewResponse from(Review review) {
+    return ReviewResponse.builder()
+        .id(review.getId())
+        .sessionId(review.getSession().getId())
+        .reviewerId(review.getReviewer().getId())
+        .reviewerNickname(review.getReviewer().getNickname())
+        .targetId(review.getTarget().getId())
+        .targetNickname(review.getTarget().getNickname())
+        .rating(review.getRating())
+        .content(review.getContent())
+        .createdAt(review.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/review/dto/ReviewResponse.java
+++ b/src/main/java/com/example/mentoring/review/dto/ReviewResponse.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.review.dto;
 
 import com.example.mentoring.review.entity.Review;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,10 +17,10 @@ public class ReviewResponse {
   // 리뷰 응답 DTO
 
   private Integer id;
-  private Integer sessionId;
-  private Integer reviewerId;
+  private UUID  sessionId;
+  private UUID  reviewerId;
   private String reviewerNickname;
-  private Integer targetId;
+  private UUID targetId;
   private String targetNickname;
   private Integer rating;
   private String content;

--- a/src/main/java/com/example/mentoring/review/dto/ReviewSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/review/dto/ReviewSummaryResponse.java
@@ -1,0 +1,35 @@
+package com.example.mentoring.review.dto;
+
+import com.example.mentoring.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewSummaryResponse {
+  // 리뷰 목록 응답 (간략) DTO
+
+  private Integer id;
+  private Integer sessionId;
+  private String reviewerNickname;
+  private Integer rating;
+  private String content;
+  private LocalDateTime createdAt;
+
+  public static ReviewSummaryResponse from(Review review) {
+    return ReviewSummaryResponse.builder()
+        .id(review.getId())
+        .sessionId(review.getSession().getId())
+        .reviewerNickname(review.getReviewer().getNickname())
+        .rating(review.getRating())
+        .content(review.getContent())
+        .createdAt(review.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/review/dto/ReviewSummaryResponse.java
+++ b/src/main/java/com/example/mentoring/review/dto/ReviewSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.example.mentoring.review.dto;
 
 import com.example.mentoring.review.entity.Review;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -16,7 +17,7 @@ public class ReviewSummaryResponse {
   // 리뷰 목록 응답 (간략) DTO
 
   private Integer id;
-  private Integer sessionId;
+  private UUID sessionId;
   private String reviewerNickname;
   private Integer rating;
   private String content;

--- a/src/main/java/com/example/mentoring/review/dto/UpdateReviewRequest.java
+++ b/src/main/java/com/example/mentoring/review/dto/UpdateReviewRequest.java
@@ -1,0 +1,24 @@
+package com.example.mentoring.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateReviewRequest {
+  // 리뷰 수정 요청 DTO
+
+  @NotNull(message = "평점은 필수 입력 값입니다.")
+  @Min(value = 1, message = "평점은 최소 1점이어야 합니다.")
+  @Max(value = 5, message = "평점은 최대 5점이어야 합니다.")
+  private Integer rating;
+
+  @NotBlank(message = "리뷰 내용은 필수 입력 값입니다.")
+  private String content;
+}

--- a/src/main/java/com/example/mentoring/review/dto/UserRatingResponse.java
+++ b/src/main/java/com/example/mentoring/review/dto/UserRatingResponse.java
@@ -1,0 +1,30 @@
+package com.example.mentoring.review.dto;
+
+import com.example.mentoring.member.entity.User;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRatingResponse {
+  // 사용자 평점 통계 DTO
+
+  private UUID userId;
+  private String nickname;
+  private Double averageRating;
+  private Long reviewCount;
+
+  public static UserRatingResponse of(User user, Double averageRating, Long reviewCount) {
+    return UserRatingResponse.builder()
+        .userId(user.getId())
+        .nickname(user.getNickname())
+        .averageRating(averageRating)
+        .reviewCount(reviewCount)
+        .build();
+  }
+}

--- a/src/main/java/com/example/mentoring/review/entity/Review.java
+++ b/src/main/java/com/example/mentoring/review/entity/Review.java
@@ -1,0 +1,106 @@
+package com.example.mentoring.review.entity;
+
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.member.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+    name = "review",
+    // 한 세션에 대해 작성자는 하나의 리뷰만 작성 가능
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_review_session_reviewer",
+            columnNames = {"session_id", "reviewer_user_id"}
+        )
+    }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Review {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Integer id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "session_id", nullable = false)
+  private Session session;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "reviewer_user_id", nullable = false)
+  private User reviewer;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "target_user_id", nullable = false)
+  private User target;
+
+  @Column(nullable = false)
+  private Integer rating; // 1 ~ 5
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @CreationTimestamp
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  // 비즈니스 로직
+  public void updateReview(Integer rating, String content) {
+    validateRating(rating);
+    this.rating = rating;
+    this.content = content;
+  }
+
+  private void validateRating(Integer rating) {
+    if (rating == null || rating < 1 || rating > 5) {
+      throw new IllegalArgumentException("평점은 1에서 5 사이여야 합니다.");
+    }
+  }
+
+  // 팩토리 메서드
+  public static Review create(Session session, User reviewer, User target, Integer rating, String content) {
+    if (!session.isCompleted()) {
+      throw new IllegalStateException("완료된 멘토링 세션에 대해서만 리뷰를 작성할 수 있습니다.");
+    }
+
+    if (!session.isParticipant(reviewer)) {
+      throw new IllegalArgumentException("해당 멘토링 세션의 참여자만 리뷰를 작성할 수 있습니다.");
+    }
+
+    if (reviewer.getId().equals(target.getId())) {
+      throw new IllegalArgumentException("자신에게 리뷰를 작성할 수 없습니다.");
+    }
+
+    Review review = Review.builder()
+        .session(session)
+        .reviewer(reviewer)
+        .target(target)
+        .rating(rating)
+        .content(content)
+        .build();
+
+    review.validateRating(rating);
+
+    return review;
+  }
+}

--- a/src/main/java/com/example/mentoring/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/mentoring/review/repository/ReviewRepository.java
@@ -1,0 +1,37 @@
+package com.example.mentoring.review.repository;
+
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.review.entity.Review;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Integer> {
+
+  // 중복 조회 방지
+  Optional<Review> findBySessionAndReviewer(Session session, User reviewer);
+
+  boolean existsBySessionAndReviewer(Session session, User reviewer);
+
+  // 목록 조회 시 작성자와 세션 정보를 함께 로딩
+  @EntityGraph(attributePaths = {"reviewer", "session"})
+  List<Review> findByTargetOrderByCreatedAtDesc(User target);
+
+  @EntityGraph(attributePaths = {"target", "session"})
+  List<Review> findByReviewerOrderByCreatedAtDesc(User reviewer);
+
+  List<Review> findBySessionOrderByCreatedAtDesc(Session session);
+
+  // 리뷰가 없으면 NULL 대신 0.0 반환
+  @Query("SELECT COALESCE(AVG(r.rating), 0.0) FROM Review r WHERE r.target = :target")
+  Double calculateAverageRatingByTarget(@Param("target") User target);
+
+  Long countByTarget(User target);
+}

--- a/src/main/java/com/example/mentoring/review/service/ReviewService.java
+++ b/src/main/java/com/example/mentoring/review/service/ReviewService.java
@@ -13,6 +13,7 @@ import com.example.mentoring.review.dto.UserRatingResponse;
 import com.example.mentoring.review.entity.Review;
 import com.example.mentoring.review.repository.ReviewRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +33,7 @@ public class ReviewService {
   private final UserRepository userRepository;
 
   @Transactional
-  public ReviewResponse createReview(Integer sessionId, Integer userId, CreateReviewRequest request) {
+  public ReviewResponse createReview(UUID sessionId, UUID userId, CreateReviewRequest request) {
     User reviewer = getUser(userId);
     Session session = getSession(sessionId);
 
@@ -51,7 +52,7 @@ public class ReviewService {
   }
 
   @Transactional
-  public ReviewResponse updateReview(Integer reviewId, Integer userId, UpdateReviewRequest request) {
+  public ReviewResponse updateReview(Integer reviewId, UUID userId, UpdateReviewRequest request) {
     Review review = getReviewEntity(reviewId);
 
     if (!review.getReviewer().getId().equals(userId)) {
@@ -67,7 +68,7 @@ public class ReviewService {
   }
 
   @Transactional
-  public void deleteReview(Integer reviewId, Integer userId) {
+  public void deleteReview(Integer reviewId, UUID userId) {
     Review review = getReviewEntity(reviewId);
 
     if (!review.getReviewer().getId().equals(userId)) {
@@ -86,28 +87,28 @@ public class ReviewService {
     return ReviewResponse.from(getReviewEntity(reviewId));
   }
 
-  public List<ReviewResponse> getReviewsBySession(Integer sessionId) {
+  public List<ReviewResponse> getReviewsBySession(UUID sessionId) {
     Session session = getSession(sessionId);
     return reviewRepository.findBySessionOrderByCreatedAtDesc(session).stream()
         .map(ReviewResponse::from)
         .collect(Collectors.toList());
   }
 
-  public List<ReviewSummaryResponse> getReceivedReviews(Integer userId) {
+  public List<ReviewSummaryResponse> getReceivedReviews(UUID userId) {
     User user = getUser(userId);
     return reviewRepository.findByTargetOrderByCreatedAtDesc(user).stream()
         .map(ReviewSummaryResponse::from)
         .collect(Collectors.toList());
   }
 
-  public List<ReviewSummaryResponse> getWrittenReviews(Integer userId) {
+  public List<ReviewSummaryResponse> getWrittenReviews(UUID userId) {
     User user = getUser(userId);
     return reviewRepository.findByReviewerOrderByCreatedAtDesc(user).stream()
         .map(ReviewSummaryResponse::from)
         .collect(Collectors.toList());
   }
 
-  public UserRatingResponse getUserRating(Integer userId) {
+  public UserRatingResponse getUserRating(UUID userId) {
     User user = getUser(userId);
 
     Double averageRating = reviewRepository.calculateAverageRatingByTarget(user);
@@ -117,12 +118,12 @@ public class ReviewService {
   }
 
   // 내부 헬퍼 메서드
-  private User getUser(Integer userId) {
+  private User getUser(UUID userId) {
     return userRepository.findById(userId)
         .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
   }
 
-  private Session getSession(Integer sessionId) {
+  private Session getSession(UUID sessionId) {
     return sessionRepository.findById(sessionId)
         .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
   }

--- a/src/main/java/com/example/mentoring/review/service/ReviewService.java
+++ b/src/main/java/com/example/mentoring/review/service/ReviewService.java
@@ -1,0 +1,167 @@
+package com.example.mentoring.review.service;
+
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.repository.SessionRepository;
+import com.example.mentoring.member.entity.MentorProfile;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import com.example.mentoring.review.dto.CreateReviewRequest;
+import com.example.mentoring.review.dto.ReviewResponse;
+import com.example.mentoring.review.dto.ReviewSummaryResponse;
+import com.example.mentoring.review.dto.UpdateReviewRequest;
+import com.example.mentoring.review.dto.UserRatingResponse;
+import com.example.mentoring.review.entity.Review;
+import com.example.mentoring.review.repository.ReviewRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+  private final ReviewRepository reviewRepository;
+  private final SessionRepository sessionRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public ReviewResponse createReview(Integer sessionId, Integer userId, CreateReviewRequest request) {
+    User reviewer = getUser(userId);
+    Session session = getSession(sessionId);
+
+    if (reviewRepository.existsBySessionAndReviewer(session, reviewer)) {
+      throw new IllegalStateException("이미 리뷰를 작성하였습니다.");
+    }
+
+    User target = getTargetUser(session, reviewer);
+
+    Review review = Review.create(session, reviewer, target, request.getRating(), request.getContent());
+    Review savedReview = reviewRepository.save(review);
+
+    updateMentorRatingIfApplicable(target);
+
+    return ReviewResponse.from(savedReview);
+  }
+
+  @Transactional
+  public ReviewResponse updateReview(Integer reviewId, Integer userId, UpdateReviewRequest request) {
+    Review review = getReviewEntity(reviewId);
+
+    if (!review.getReviewer().getId().equals(userId)) {
+      throw new IllegalStateException("본인이 작성한 리뷰만 수정할 수 있습니다.");
+    }
+
+    review.updateReview(request.getRating(), request.getContent());
+
+    // 평점 재계산
+    updateMentorRatingIfApplicable(review.getTarget());
+
+    return ReviewResponse.from(review);
+  }
+
+  @Transactional
+  public void deleteReview(Integer reviewId, Integer userId) {
+    Review review = getReviewEntity(reviewId);
+
+    if (!review.getReviewer().getId().equals(userId)) {
+      throw new IllegalStateException("본인이 작성한 리뷰만 삭제할 수 있습니다.");
+    }
+
+    User target = review.getTarget();
+    reviewRepository.delete(review);
+
+    updateMentorRatingIfApplicable(target);
+  }
+
+  // 조회 메서드
+
+  public ReviewResponse getReview(Integer reviewId) {
+    return ReviewResponse.from(getReviewEntity(reviewId));
+  }
+
+  public List<ReviewResponse> getReviewsBySession(Integer sessionId) {
+    Session session = getSession(sessionId);
+    return reviewRepository.findBySessionOrderByCreatedAtDesc(session).stream()
+        .map(ReviewResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  public List<ReviewSummaryResponse> getReceivedReviews(Integer userId) {
+    User user = getUser(userId);
+    return reviewRepository.findByTargetOrderByCreatedAtDesc(user).stream()
+        .map(ReviewSummaryResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  public List<ReviewSummaryResponse> getWrittenReviews(Integer userId) {
+    User user = getUser(userId);
+    return reviewRepository.findByReviewerOrderByCreatedAtDesc(user).stream()
+        .map(ReviewSummaryResponse::from)
+        .collect(Collectors.toList());
+  }
+
+  public UserRatingResponse getUserRating(Integer userId) {
+    User user = getUser(userId);
+
+    Double averageRating = reviewRepository.calculateAverageRatingByTarget(user);
+    Long reviewCount = reviewRepository.countByTarget(user);
+
+    return UserRatingResponse.of(user, roundRating(averageRating), reviewCount);
+  }
+
+  // 내부 헬퍼 메서드
+  private User getUser(Integer userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+  }
+
+  private Session getSession(Integer sessionId) {
+    return sessionRepository.findById(sessionId)
+        .orElseThrow(() -> new IllegalArgumentException("세션을 찾을 수 없습니다."));
+  }
+
+  private Review getReviewEntity(Integer reviewId) {
+    return reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
+  }
+
+  private User getTargetUser(Session session, User reviewer) {
+    if (session.getMentor().getId().equals(reviewer.getId())) {
+      return session.getMentee();
+    } else {
+      return session.getMentor();
+    }
+  }
+
+  // 멘토 프로필 평점 업데이트 로직
+  private void updateMentorRatingIfApplicable(User target) {
+    if (target.getRole() != User.Role.MENTOR) {
+      return;
+    }
+
+    MentorProfile profile = target.getMentorProfile();
+    if (profile == null) {
+      return;
+    }
+
+    Double averageRating = reviewRepository.calculateAverageRatingByTarget(target);
+    Long reviewCount = reviewRepository.countByTarget(target);
+
+    // BigDecimal로 변환하여 소수점 1자리로 반올림
+    BigDecimal roundedRating = BigDecimal.valueOf(averageRating)
+        .setScale(1, RoundingMode.HALF_UP);
+
+    profile.updateRating(roundedRating, reviewCount);
+  }
+
+  private Double roundRating(Double rating) {
+    return Math.round(rating * 10.0) / 10.0;
+  }
+}

--- a/src/test/java/com/example/mentoring/match/repository/PostRepositoryTest.java
+++ b/src/test/java/com/example/mentoring/match/repository/PostRepositoryTest.java
@@ -1,0 +1,180 @@
+package com.example.mentoring.match.repository;
+
+import com.example.mentoring.global.code.FieldCode;
+import com.example.mentoring.global.code.LevelCode;
+import com.example.mentoring.global.config.QueryDslConfig;
+import com.example.mentoring.match.dto.PostResponse;
+import com.example.mentoring.match.dto.PostSearchCondition;
+import com.example.mentoring.match.entity.Post;
+import com.example.mentoring.match.entity.PostTag;
+import com.example.mentoring.match.entity.Tag;
+import com.example.mentoring.match.entity.TagType;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class) // QueryDSL 설정 가져옴
+class PostRepositoryTest {
+
+  @Autowired
+  PostRepository postRepository;
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  TagRepository tagRepository;
+
+  @Autowired
+  EntityManager em;
+
+  User mentor;
+  Tag springTag;
+  Tag javaTag;
+
+  @BeforeEach
+  void setUp() {
+    // 테스트에 공통으로 필요한 데이터 세팅
+    mentor = User.builder()
+        .email("mentor@test.com")
+        .password("password")
+        .nickname("멘토킴")
+        .role(User.Role.MENTOR)
+        .build();
+    userRepository.save(mentor);
+
+    springTag = tagRepository.save(Tag.create("Spring", TagType.STACK));
+    javaTag = tagRepository.save(Tag.create("Java", TagType.STACK));
+  }
+
+  @Test
+  @DisplayName("검색 조건이 없으면 모집 중인 모든 글을 조회한다")
+  void search_noCondition() {
+    // given
+    createPost("제목1", "내용1", List.of(springTag));
+    createPost("제목2", "내용2", List.of(javaTag));
+
+    PostSearchCondition condition = new PostSearchCondition(); // 조건 없음
+    Pageable pageable = PageRequest.of(0, 10);
+
+    // when
+    Page<PostResponse> result = postRepository.search(condition, pageable);
+
+    // then
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("키워드 검색: 제목 또는 내용에 키워드가 포함된 글을 찾는다")
+  void search_keyword() {
+    // given
+    createPost("스프링 부트 강의", "기초부터 심화까지", List.of(springTag));
+    createPost("자바의 정석", "언어 기초", List.of(javaTag));
+
+    PostSearchCondition condition = new PostSearchCondition();
+    condition.setKeyword("스프링"); // "스프링" 검색
+
+    // when
+    Page<PostResponse> result = postRepository.search(condition, PageRequest.of(0, 10));
+
+    // then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getTitle()).contains("스프링");
+  }
+
+  @Test
+  @DisplayName("태그 검색: 특정 태그를 가진 글만 필터링한다")
+  void search_tag() {
+    // given
+    createPost("글1", "내용1", List.of(springTag));
+    createPost("글2", "내용2", List.of(javaTag));
+    createPost("글3", "내용3", List.of(springTag, javaTag));
+
+    PostSearchCondition condition = new PostSearchCondition();
+    condition.setTagIds(List.of(springTag.getId())); // Spring 태그 선택
+
+    // when
+    Page<PostResponse> result = postRepository.search(condition, PageRequest.of(0, 10));
+
+    // then
+    // 글1, 글3이 나와야 함
+    assertThat(result.getContent()).hasSize(2);
+    assertThat(result.getContent())
+        .extracting("title")
+        .containsExactlyInAnyOrder("글1", "글3");
+  }
+
+  @Test
+  @DisplayName("복합 검색: 키워드와 태그 조건을 모두 만족하는 글을 찾는다")
+  void search_complex() {
+    // given
+    createPost("스프링 백엔드", "모집합니다", List.of(springTag)); // O (스프링 + Spring태그)
+    createPost("스프링 프론트", "모집합니다", List.of(javaTag));   // X (태그 불일치)
+    createPost("자바 백엔드", "모집합니다", List.of(springTag));   // X (키워드 불일치)
+
+    PostSearchCondition condition = new PostSearchCondition();
+    condition.setKeyword("스프링");
+    condition.setTagIds(List.of(springTag.getId()));
+
+    // when
+    Page<PostResponse> result = postRepository.search(condition, PageRequest.of(0, 10));
+
+    // then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getTitle()).isEqualTo("스프링 백엔드");
+  }
+
+  @Test
+  @DisplayName("모집 마감된 글은 조회되지 않아야 한다")
+  void search_excludeClosed() {
+    // given
+    Post post = createPost("마감된 글", "내용", List.of(springTag));
+    post.closeRecruitment(); // 모집 마감 처리
+    postRepository.save(post);
+
+    createPost("모집중인 글", "내용", List.of(springTag));
+
+    PostSearchCondition condition = new PostSearchCondition();
+
+    // when
+    Page<PostResponse> result = postRepository.search(condition, PageRequest.of(0, 10));
+
+    // then
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getTitle()).isEqualTo("모집중인 글");
+  }
+
+  private Post createPost(String title, String content, List<Tag> tags) {
+    Post post = Post.builder()
+        .user(mentor)
+        .title(title)
+        .content(content)
+        .fieldCode(FieldCode.BACK)
+        .levelCode(LevelCode.LV0)
+        .isRecruiting(true)
+        .build();
+
+    if (tags != null) {
+      for (Tag tag : tags) {
+        post.addPostTag(PostTag.builder().tag(tag).post(post).build());
+      }
+    }
+
+    return postRepository.save(post);
+  }
+}

--- a/src/test/java/com/example/mentoring/match/service/ApplicationServiceTest.java
+++ b/src/test/java/com/example/mentoring/match/service/ApplicationServiceTest.java
@@ -7,6 +7,7 @@ import com.example.mentoring.match.event.ApplicationApprovedEvent;
 import com.example.mentoring.match.repository.ApplicationRepository;
 import com.example.mentoring.member.entity.User;
 import com.example.mentoring.member.repository.UserRepository;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +41,7 @@ class ApplicationServiceTest {
   @DisplayName("멘토링 신청 승인 성공 및 이벤트 발행 테스트")
   void approveApplication_Success() {
     // given
-    Integer applicationId = 1;
+    UUID applicationId = 1;
     Integer mentorId = 10;
     Integer menteeId = 20;
 

--- a/src/test/java/com/example/mentoring/match/service/PostServiceTest.java
+++ b/src/test/java/com/example/mentoring/match/service/PostServiceTest.java
@@ -1,0 +1,156 @@
+package com.example.mentoring.match.service;
+
+import com.example.mentoring.match.dto.UpdatePostRequest;
+import com.example.mentoring.match.entity.Post;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.MentorProfileRepository;
+import com.example.mentoring.member.entity.MentorProfile;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.example.mentoring.member.repository.UserRepository;
+import com.example.mentoring.match.repository.PostRepository;
+import com.example.mentoring.match.repository.TagRepository;
+import com.example.mentoring.global.code.FieldCode;
+import com.example.mentoring.global.code.LevelCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+  @InjectMocks
+  private PostService postService;
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private TagRepository tagRepository;
+
+  @Mock
+  private MentorProfileRepository mentorProfileRepository;
+
+  private User testUser;
+  private Post testPost;
+  private UpdatePostRequest updateRequest;
+
+  // 테스트 시작 전 공통 객체 초기화
+  @BeforeEach
+  void setUp() {
+    testUser = User.builder()
+        .id(1)
+        .nickname("멘토1")
+        .build();
+
+    // 초기 Post 객체
+    testPost = Post.builder()
+        .id(100)
+        .user(testUser)
+        .title("오래된 제목")
+        .content("오래된 내용")
+        .fieldCode(FieldCode.BACK)
+        .levelCode(LevelCode.LV2)
+        // Auditing 테스트를 위해 임의의 초기 시간 설정
+        .createdAt(LocalDateTime.of(2025, 1, 1, 10, 0))
+        .updatedAt(LocalDateTime.of(2025, 1, 1, 10, 0))
+        .build();
+
+    updateRequest = new UpdatePostRequest(
+        "새로운 제목",
+        "새로운 내용",
+        FieldCode.FRONT.name(),
+        LevelCode.LV4.name(),
+        null
+    );
+  }
+  @Test
+  @DisplayName("게시글 수정 시 updatedAt이 자동으로 업데이트되어야 한다")
+  void updatePost_shouldUpdateUpdatedAt() throws Exception {
+    // Given
+    when(userRepository.findById(anyInt())).thenReturn(Optional.of(testUser));
+    when(postRepository.findById(anyInt())).thenReturn(Optional.of(testPost));
+
+    // 서비스 메서드 호출 전에 초기 시간을 기록
+    LocalDateTime initialUpdatedAt = testPost.getUpdatedAt();
+
+    // When
+    // 서비스 메서드 실행
+    postService.updatePost(testPost.getId(), testUser.getId(), updateRequest);
+
+    // Then
+    assertThat(testPost.getTitle()).isEqualTo("새로운 제목");
+    assertThat(testPost.getContent()).isEqualTo("새로운 내용");
+
+    // (Post 객체의 updatePost 메서드 호출 여부 확인)
+    verify(postRepository, times(1)).findById(testPost.getId());
+  }
+
+  @Test
+  @DisplayName("멘토 레벨보다 높은 레벨로 게시글 수정 시 예외가 발생해야 한다")
+  void updatePost_shouldThrowException_whenRequestLevelExceedsMentorLevel() {
+    // Given
+    MentorProfile lowLevelProfile = MentorProfile.builder()
+        .user(testUser)
+        .levelCode(LevelCode.LV2)
+        .build();
+
+    // 멘토 레벨 < 요청 레벨
+    UpdatePostRequest highLevelRequest = new UpdatePostRequest(
+        "제목", "내용", FieldCode.FRONT.name(), LevelCode.LV4.name(), null
+    );
+
+    when(userRepository.findById(anyInt())).thenReturn(Optional.of(testUser));
+    when(postRepository.findById(anyInt())).thenReturn(Optional.of(testPost));
+
+    when(mentorProfileRepository.findByUserId(anyInt())).thenReturn(Optional.of(lowLevelProfile));
+
+    // When & Then
+    // 예외가 발생하는지 검증
+    assertThat(assertThrows(IllegalArgumentException.class, () ->
+        postService.updatePost(testPost.getId(), testUser.getId(), highLevelRequest)
+    )).hasMessageContaining("높은 레벨"); // 예외 메시지 일부 확인
+  }
+
+  @Test
+  @DisplayName("멘토 레벨 이하의 레벨로 게시글 수정 시 성공해야 한다")
+  void updatePost_shouldSucceed_whenRequestLevelIsValid() {
+    // Given
+    MentorProfile highLevelProfile = MentorProfile.builder()
+        .user(testUser)
+        .levelCode(LevelCode.LV4)
+        .build();
+
+    // 멘토 레벨 > 요청 레벨
+    UpdatePostRequest validLevelRequest = new UpdatePostRequest(
+        "제목", "내용", FieldCode.FRONT.name(), LevelCode.LV2.name(), null
+    );
+
+    when(userRepository.findById(anyInt())).thenReturn(Optional.of(testUser));
+    when(postRepository.findById(anyInt())).thenReturn(Optional.of(testPost));
+
+    when(mentorProfileRepository.findByUserId(anyInt())).thenReturn(Optional.of(highLevelProfile));
+
+    // When
+    postService.updatePost(testPost.getId(), testUser.getId(), validLevelRequest);
+
+    // Then
+    // 게시글 내용이 정상적으로 업데이트되었는지 확인
+    assertThat(testPost.getLevelCode()).isEqualTo(LevelCode.LV2);
+
+    // 메서드 호출 확인
+    verify(mentorProfileRepository, times(1)).findByUserId(testUser.getId());
+  }
+}

--- a/src/test/java/com/example/mentoring/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/example/mentoring/review/service/ReviewServiceTest.java
@@ -1,0 +1,242 @@
+package com.example.mentoring.review.service;
+
+import com.example.mentoring.global.code.FieldCode;
+import com.example.mentoring.global.code.LevelCode;
+import com.example.mentoring.match.entity.Session;
+import com.example.mentoring.match.repository.SessionRepository;
+import com.example.mentoring.member.entity.MentorProfile;
+import com.example.mentoring.member.entity.User;
+import com.example.mentoring.member.repository.UserRepository;
+import com.example.mentoring.review.dto.CreateReviewRequest;
+import com.example.mentoring.review.dto.ReviewResponse;
+import com.example.mentoring.review.dto.UpdateReviewRequest;
+import com.example.mentoring.review.dto.UserRatingResponse;
+import com.example.mentoring.review.entity.Review;
+import com.example.mentoring.review.repository.ReviewRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID; // UUID import 추가
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+  @InjectMocks
+  private ReviewService reviewService;
+
+  @Mock
+  private ReviewRepository reviewRepository;
+
+  @Mock
+  private SessionRepository sessionRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("리뷰 생성 성공: 멘티가 멘토에게 리뷰를 작성하고 평점이 갱신된다")
+  void createReview_success() {
+    // given
+    User mentor = createMentor(1);
+    User mentee = createMentee(2);
+    // UUID 생성
+    UUID sessionId = UUID.randomUUID();
+    Session session = createCompletedSession(sessionId, mentor, mentee);
+
+    CreateReviewRequest request = new CreateReviewRequest(5, "훌륭한 멘토링이었습니다!");
+
+    // Mocking
+    given(userRepository.findById(2)).willReturn(Optional.of(mentee));
+    // UUID로 조회
+    given(sessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+    given(reviewRepository.existsBySessionAndReviewer(session, mentee)).willReturn(false);
+    given(reviewRepository.calculateAverageRatingByTarget(mentor)).willReturn(4.5);
+    given(reviewRepository.countByTarget(mentor)).willReturn(10L);
+
+    Review savedReview = Review.create(session, mentee, mentor, 5, "content");
+    ReflectionTestUtils.setField(savedReview, "id", 1);
+    given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
+
+    // when
+    // service 호출 시 UUID 전달
+    ReviewResponse response = reviewService.createReview(sessionId, 2, request);
+
+    // then
+    assertThat(response.getReviewerId()).isEqualTo(mentee.getId());
+    assertThat(response.getTargetId()).isEqualTo(mentor.getId());
+
+    assertThat(mentor.getMentorProfile().getAvgRating()).isEqualTo(BigDecimal.valueOf(4.5));
+    assertThat(mentor.getMentorProfile().getReviewCount()).isEqualTo(10L);
+
+    verify(reviewRepository, times(1)).save(any(Review.class));
+  }
+
+  @Test
+  @DisplayName("리뷰 생성 실패: 완료되지 않은 세션에는 리뷰를 작성할 수 없다")
+  void createReview_fail_sessionNotCompleted() {
+    // given
+    User mentor = createMentor(1);
+    User mentee = createMentee(2);
+    UUID sessionId = UUID.randomUUID();
+
+    // 진행 중인 세션 생성
+    Session session = Session.builder()
+        .id(sessionId)
+        .mentor(mentor)
+        .mentee(mentee)
+        .status(Session.SessionStatus.PROGRESS) // 진행 중
+        .build();
+
+    given(userRepository.findById(2)).willReturn(Optional.of(mentee));
+    given(sessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+
+    CreateReviewRequest request = new CreateReviewRequest(5, "내용");
+
+    // when & then
+    assertThatThrownBy(() -> reviewService.createReview(sessionId, 2, request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("완료된 멘토링 세션에 대해서만 리뷰를 작성할 수 있습니다.");
+  }
+
+  @Test
+  @DisplayName("리뷰 생성 실패: 이미 리뷰를 작성한 경우 중복 작성 불가")
+  void createReview_fail_duplicate() {
+    // given
+    User mentor = createMentor(1);
+    User mentee = createMentee(2);
+    UUID sessionId = UUID.randomUUID();
+    Session session = createCompletedSession(sessionId, mentor, mentee);
+
+    given(userRepository.findById(2)).willReturn(Optional.of(mentee));
+    given(sessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+    given(reviewRepository.existsBySessionAndReviewer(session, mentee)).willReturn(true);
+
+    CreateReviewRequest request = new CreateReviewRequest(5, "내용");
+
+    // when & then
+    assertThatThrownBy(() -> reviewService.createReview(sessionId, 2, request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("이미 리뷰를 작성하였습니다.");
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 성공: 내용과 평점을 수정하고 멘토 통계를 갱신한다")
+  void updateReview_success() {
+    // given
+    User mentor = createMentor(1);
+    User mentee = createMentee(2);
+    UUID sessionId = UUID.randomUUID();
+    Session session = createCompletedSession(sessionId, mentor, mentee);
+
+    Review review = Review.create(session, mentee, mentor, 3, "이전 내용");
+    ReflectionTestUtils.setField(review, "id", 1);
+
+    UpdateReviewRequest request = new UpdateReviewRequest(5, "수정된 내용");
+
+    given(reviewRepository.findById(1)).willReturn(Optional.of(review));
+    given(reviewRepository.calculateAverageRatingByTarget(mentor)).willReturn(5.0);
+    given(reviewRepository.countByTarget(mentor)).willReturn(1L);
+
+    // when
+    ReviewResponse response = reviewService.updateReview(1, 2, request);
+
+    // then
+    assertThat(response.getContent()).isEqualTo("수정된 내용");
+    assertThat(response.getRating()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("리뷰 수정 실패: 본인이 작성하지 않은 리뷰는 수정할 수 없다")
+  void updateReview_fail_notOwner() {
+    // given
+    User mentor = createMentor(1);
+    User mentee = createMentee(2);
+    User otherUser = createMentee(3);
+
+    UUID sessionId = UUID.randomUUID();
+    Session session = createCompletedSession(sessionId, mentor, mentee);
+    Review review = Review.create(session, mentee, mentor, 3, "내용");
+
+    given(reviewRepository.findById(1)).willReturn(Optional.of(review));
+
+    UpdateReviewRequest request = new UpdateReviewRequest(4, "수정");
+
+    // when & then
+    assertThatThrownBy(() -> reviewService.updateReview(1, 3, request))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("본인이 작성한 리뷰만 수정할 수 있습니다.");
+  }
+
+  @Test
+  @DisplayName("사용자 평점 조회: 평점이 없는 경우 0.0을 반환한다")
+  void getUserRating_nullSafety() {
+    // 기존 코드 동일 (User ID는 Integer 유지)
+    User user = createMentor(1);
+    given(userRepository.findById(1)).willReturn(Optional.of(user));
+
+    given(reviewRepository.calculateAverageRatingByTarget(user)).willReturn(0.0);
+    given(reviewRepository.countByTarget(user)).willReturn(0L);
+
+    UserRatingResponse response = reviewService.getUserRating(1);
+
+    assertThat(response.getAverageRating()).isEqualTo(0.0);
+    assertThat(response.getReviewCount()).isEqualTo(0L);
+  }
+
+  // 테스트 데이터
+  private User createMentor(Integer id) {
+    // ... 기존 코드 동일
+    User user = User.builder()
+        .id(id)
+        .email("mentor" + id + "@test.com")
+        .nickname("멘토" + id)
+        .role(User.Role.MENTOR)
+        .build();
+    MentorProfile profile = MentorProfile.builder()
+        .user(user)
+        .fieldCode(FieldCode.BACK)
+        .levelCode(LevelCode.LV3)
+        .avgRating(BigDecimal.ZERO)
+        .reviewCount(0L)
+        .build();
+    ReflectionTestUtils.setField(user, "mentorProfile", profile);
+    return user;
+  }
+
+  private User createMentee(Integer id) {
+    // ... 기존 코드 동일
+    return User.builder()
+        .id(id)
+        .email("mentee" + id + "@test.com")
+        .nickname("멘티" + id)
+        .role(User.Role.MENTEE)
+        .build();
+  }
+
+  // Integer id -> UUID id 변경
+  private Session createCompletedSession(UUID id, User mentor, User mentee) {
+    return Session.builder()
+        .id(id)
+        .mentor(mentor)
+        .mentee(mentee)
+        .status(Session.SessionStatus.COMPLETED)
+        .startDate(LocalDateTime.now().minusDays(1))
+        .endDate(LocalDateTime.now())
+        .build();
+  }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+        format_sql: true
+        show_sql: true
+
+# 로그 레벨 조정
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 리뷰 관련 CRUD 및 평점 통계 기능이 부재했습니다.
- 게시글 목록 조회만 가능하며, 상세 조건별 검색 기능이 부재했습니다.
- 게시글 수정 시 updatedAt 필드 추적이 미흡하여 수동 처리가 필요했습니다.
- 멘토링 모집 글 작성 시, 모집 레벨에 대한 멘토 자격 검증 로직이 부재했습니다.

**TO-BE**
- Review 엔티티를 작성하고 Session 엔티티의 완료 상태/참여자 로직(isCompleted(), isParticipant())을 활용하였습니다.
- 리뷰 평점 관리를 위한 updateRatingavg 비즈니스 메서드를 추가하여 그동안의 리뷰에서 평균 별점을 계산합니다 (리뷰 수가 0이면 0.0)
- **ReviewService**에서 리뷰 CUD(Create/Update/Delete) 발생 시, MentorProfile의 평점 통계 필드를 **트랜잭션 내에서 즉시 갱신(동기화)** 하도록 구현했습니다.
- 다양한 조건(직무, 수준 등)을 이용한 searchPosts 기능을 구현하여 검색 편의성을 제공하였습니다.
- PostService에 멘토 프로필 기반 레벨 초과 모집 제한 검증 로직을 추가하였습니다. (LV2 멘토가 LV4 게시글을 쓸 수 없음)


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드 : 기능 구현 단위 테스트와 함께 updatedAt을 추적하기 위한 JPA Auditing 관련 테스트 코드를 추가했습니다.
- [ ] API 테스트 